### PR TITLE
Fix clear icon is displayed when clear-icon slot is added

### DIFF
--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -44,7 +44,7 @@
                 class="dp__input_icon dp__input_icons"
                 @click="stopPropagation"
             />
-            <span class="dp__clear_icon" v-if="$slots['clear-icon'] && clearable && !disabled && !readonly"
+            <span class="dp__clear_icon" v-if="$slots['clear-icon'] && inputValue && clearable && !disabled && !readonly"
                 ><slot name="clear-icon" :clear="onClear"
             /></span>
             <CancelIcon


### PR DESCRIPTION
Hello,

I noticed a weird behavior on the clear icon when using it with a custom slot.
The clear icon is still displayed when there are no value set.