### PR TITLE
Add `"type": "module"` to package.json for Vite resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "homepage": "https://vue3datepicker.com",
   "types": "index.d.ts",
+  "type": "module",
   "main": "dist/vue-datepicker.umd.js",
   "module": "dist/vue-datepicker.es.js",
   "browser": "dist/vue-datepicker.es.js",


### PR DESCRIPTION
I have a project that uses this datepicker. I'm creating an SSR build of the project using Vite. When trying to run the resulting bundle using `node`, a `Cannot use import statement outside a module` error happens. Vite correctly imports the `vue-datepicker.es.js` file, but then incorrectly treats it as a CommonJS module. This happens because Vite seems to only treat modules as ES modules if the `package.json` specifies the `type` as `module`.

If I manually edit the `package.json` in my `node_modules` folder to include `"type": "module"`, everything works as expected.
