### PR TITLE
fix: ActionIcon accessibility issues

### DIFF
--- a/src/VueDatePicker/components/MonthYearPicker/ActionIcon.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/ActionIcon.vue
@@ -4,9 +4,11 @@
         @click="$emit('activate')"
         @keydown.enter="$emit('activate')"
         tabindex="0"
+        role="button"
+        :aria-label="ariaLabel"
         ref="elRef"
     >
-        <div class="dp__inner_nav" role="button" :aria-label="ariaLabel">
+        <div class="dp__inner_nav">
             <slot />
         </div>
     </div>

--- a/src/VueDatePicker/components/MonthYearPicker/MonthYearPicker.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/MonthYearPicker.vue
@@ -53,7 +53,7 @@
                 <ChevronUpIcon v-if="!$slots['arrow-up']" />
             </ActionIcon>
             <ActionIcon
-                :arial-label="ariaLabels.nextMonth"
+                :aria-label="ariaLabels.nextMonth"
                 @activate="handleMonthYearChange(true)"
                 ref="rightIcon"
                 v-if="showRightIcon"


### PR DESCRIPTION
To fix [DatePick issue.](https://github.com/Vuepic/vue-datepicker/issues/132)

To fix a minor issues with Prev/Next buttons
1. Screenreader announces ActionIcon as "group" instead of "button".
2. Next Month ActionIcon aria label prop typo