### PR TITLE
feat: support keyboard Esc to close month/year, or hour/minute overlay depending on prop escClose

### DIFF
--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -60,6 +60,7 @@
                                     reverseYears,
                                     vertical,
                                     yearPicker,
+                                    escClose,
                                 }"
                                 @mount="childMount('monthYearInput')"
                                 @reset-flow="resetFlow"
@@ -125,6 +126,7 @@
                                 fixedEnd,
                                 modelAuto,
                                 internalModelValue,
+                                escClose,
                             }"
                             @mount="childMount('timePicker')"
                             @update:hours="updateTime($event)"

--- a/src/VueDatePicker/components/MonthYearPicker/MonthYearPicker.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/MonthYearPicker.vue
@@ -198,6 +198,7 @@
         filters: { type: Object as PropType<IDateFilter>, default: () => ({}) },
         multiCalendarsSolo: { type: Boolean as PropType<boolean>, default: false },
         yearPicker: { type: Boolean as PropType<boolean>, default: false },
+        escClose: { type: Boolean as PropType<boolean>, default: true },
     });
 
     const { transitionName, showTransition } = useTransitions();
@@ -245,6 +246,7 @@
             maxValue: (isMonth ? maxMonth : maxYear).value,
             headerRefs:
                 isMonth && props.monthPicker ? [mpPrevIconRef.value, mpYearButtonRef.value, mpNextIconRef.value] : [],
+            escClose: props.escClose,
         };
     });
 

--- a/src/VueDatePicker/components/MonthYearPicker/RegularPicker.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/RegularPicker.vue
@@ -20,6 +20,7 @@
                 disabledValues,
                 minValue,
                 maxValue,
+                escClose,
             }"
             :header-refs="[]"
             @update:model-value="$emit('update:model-value', $event)"
@@ -57,6 +58,7 @@
         maxValue: { type: Number as PropType<number>, default: null },
         slotName: { type: String as PropType<string>, default: '' },
         headerRefs: { type: Array as PropType<HTMLElement[]>, default: () => [] },
+        escClose: { type: Boolean as PropType<boolean>, default: true },
     });
 
     const { transitionName, showTransition } = useTransitions();

--- a/src/VueDatePicker/components/SelectionGrid.vue
+++ b/src/VueDatePicker/components/SelectionGrid.vue
@@ -1,5 +1,5 @@
 <template>
-    <div ref="gridWrapRef" :class="dpOverlayClass" role="dialog" tabindex="0">
+    <div ref="gridWrapRef" :class="dpOverlayClass" role="dialog" tabindex="0" @keydown.esc="handleEsc">
         <div :class="containerClass" role="grid">
             <div class="dp__selection_grid_header"><slot name="header"></slot></div>
             <div class="dp__overlay_row" v-for="(row, i) in mappedItems" :key="getKey(i)" role="row">
@@ -66,6 +66,7 @@
         skipButtonRef: { type: Boolean as PropType<boolean>, default: false },
         monthPicker: { type: Boolean as PropType<boolean>, default: false },
         yearPicker: { type: Boolean as PropType<boolean>, default: false },
+        escClose: { type: Boolean as PropType<boolean>, default: true },
     });
 
     const scrollable = ref(false);
@@ -247,6 +248,12 @@
     const toggle = () => {
         emit('toggle');
         emit('reset-flow');
+    };
+
+    const handleEsc = () => {
+        if (props.escClose) {
+            toggle();
+        }
     };
 
     const assignRef = (el: HTMLElement, col: IDefaultSelect, rowInd: number, colInd: number): void => {

--- a/src/VueDatePicker/components/TimePicker/TimeInput.vue
+++ b/src/VueDatePicker/components/TimePicker/TimeInput.vue
@@ -76,6 +76,7 @@
                 v-if="overlays[timeInput.type]"
                 :items="getGridItems(timeInput.type)"
                 :disabled-values="filters.times[timeInput.type]"
+                :esc-close="escClose"
                 @update:model-value="handleTimeFromOverlay(timeInput.type, $event)"
                 @selected="toggleOverlay(timeInput.type)"
                 @toggle="toggleOverlay(timeInput.type)"
@@ -135,6 +136,7 @@
         disabled: { type: Boolean as PropType<boolean>, default: false },
         closeTimePickerBtn: { type: Object as PropType<HTMLElement>, default: null },
         order: { type: Number as PropType<0 | 1>, default: 0 },
+        escClose: { type: Boolean as PropType<boolean>, default: true },
     });
 
     const overlays = reactive({

--- a/src/VueDatePicker/components/TimePicker/TimePicker.vue
+++ b/src/VueDatePicker/components/TimePicker/TimePicker.vue
@@ -54,6 +54,7 @@
                                     noSecondsOverlay,
                                     enableSeconds,
                                     closeTimePickerBtn,
+                                    escClose,
                                     order: index,
                                 }"
                                 @update:hours="updateHours(getEvent($event, index, 'hours'))"
@@ -124,6 +125,7 @@
         customProps: { type: Object as PropType<Record<string, unknown>>, default: null },
         modelAuto: { type: Boolean as PropType<boolean>, default: false },
         internalModelValue: { type: [Date, Array] as PropType<InternalModuleValue>, default: null },
+        escClose: { type: Boolean as PropType<boolean>, default: true },
     });
     const slots = useSlots();
     const openTimePickerBtn = ref(null);

--- a/tests/unit/logic.spec.ts
+++ b/tests/unit/logic.spec.ts
@@ -30,6 +30,15 @@ const mountDatepicker = async (props: any = {}): Promise<{ dp: VueWrapper<any>; 
     return { dp, menu };
 };
 
+const openAndGetMonthOverlay = async (menu: VueWrapper<any>) => {
+    const monthYearInput = menu.findComponent(MonthYearInput);
+    monthYearInput.vm.toggleMonthPicker();
+
+    await monthYearInput.vm.$nextTick();
+
+    return menu.find('.dp__overlay');
+};
+
 /**
  * Commented code is not working in vue 3.2.33, looks like the second emit is not working after next tick
  * will wait for the update
@@ -242,5 +251,27 @@ describe('Logic connection', () => {
 
         expect(dp.vm.internalModelValue).toHaveLength(2);
         expect(dp.vm.internalModelValue).toEqual(weekRange);
+    });
+
+    it('Should close month overlay on pressing keyboard Esc when escClose = true', async () => {
+        const { menu } = await mountDatepicker({ inline: true, escClose: true });
+
+        // trigger keypress Esc
+        const overlayBefore = await openAndGetMonthOverlay(menu);
+        await overlayBefore.trigger('keydown.esc');
+
+        const overlayAfter = menu.findAll('.dp__overlay');
+        expect(overlayAfter).toHaveLength(0);
+    });
+
+    it('Should not close month overlay on pressing keyboard Esc when escClose = false', async () => {
+        const { menu } = await mountDatepicker({ inline: true, escClose: false });
+
+        // trigger keypress Esc
+        const overlayBefore = await openAndGetMonthOverlay(menu);
+        await overlayBefore.trigger('keydown.esc');
+
+        const overlayAfter = menu.findAll('.dp__overlay');
+        expect(overlayAfter).toHaveLength(1);
     });
 });

--- a/tests/unit/logic.spec.ts
+++ b/tests/unit/logic.spec.ts
@@ -192,7 +192,7 @@ describe('Logic connection', () => {
     });
 
     it('Should format with locale', async () => {
-        const selected = new Date(0);
+        const selected = new Date(1970, 0, 1);
         // The day of the week (E) is locale-sensitive in Japanese.
         // Since epoch time zero (1970/1/1) was a Thursday, the 'Thu' must be localized to '木'.
         const { dp, menu } = await mountDatepicker({


### PR DESCRIPTION
For [issue 139](https://github.com/Vuepic/vue-datepicker/issues/139).

Affected: month/year/hour/minute overlay
1. When DatePicker is in dropdown mode: same behavior as before
   -escClose=true, keypress Esc will close overlay if any is showing. It also closes date picker menu.
   -escClose=false, Esc does nothing 
2. When in inline mode:
   -escClose=true, Esc will close month/year/hour/minute overlay (new behavior)
   -escClose=false, Esc does nothing