### PR TITLE
refactor(type definition): export interfaces in declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 import { Locale } from 'date-fns';
 import { ComponentOptionsMixin, ComputedOptions, DefineComponent, MethodOptions } from 'vue';
 
-type EmitEvents =
+export type EmitEvents =
     | 'update:modelValue'
     | 'textSubmit'
     | 'closed'
@@ -16,7 +16,7 @@ type EmitEvents =
     | 'updateMonthYear'
     | 'invalid-select';
 
-interface VueDatePicker {
+export interface VueDatePicker {
     uid?: string;
     name?: string;
     is24?: boolean;
@@ -233,7 +233,7 @@ interface VueDatePicker {
     ignoreTimeValidation?: boolean;
 }
 
-interface PublicMethods extends MethodOptions {
+export interface PublicMethods extends MethodOptions {
     selectDate: () => void;
     closeMenu: () => void;
     openMenu: () => void;


### PR DESCRIPTION
When extending vue-datepicker with custom implementations, importing interfaces individually (as opposed to the `_default` export typed as `DefineComponent`) helps keep typing in-sync.