### PR TITLE
add html as optional parameter to calendar marker's tooltips

### DIFF
--- a/src/VueDatePicker/components/Calendar.vue
+++ b/src/VueDatePicker/components/Calendar.vue
@@ -75,7 +75,8 @@
                                                         class="dp__tooltip_mark"
                                                         :style="tooltip.color ? { backgroundColor: tooltip.color } : {}"
                                                     ></div>
-                                                    <div>{{ tooltip.text }}</div>
+                                                    <div v-if="tooltip.html" v-html="tooltip.html"></div>
+                                                    <div v-else>{{ tooltip.text }}</div>
                                                 </template>
                                             </div>
                                             <div class="dp__arrow_bottom_tp"></div>


### PR DESCRIPTION
helps to style the tooltips of markers by using `html` parameter instead of `text` when adding markers

e.g. 
```js
 const markers = ref([
         
          {
            date: new Date(),
            type: 'line',
            tooltip: [
              { html: 'First tooltip <br> <b>fff</b>', color: 'blue' },
              { text: 'Second tooltip', color: 'yellow' },
            ],
          }
        ])
```

**potential issue:** depending on where the data  for the markers comes from, opens the code up for code injection. 