### PR TITLE
[Accessibility] Allow aria-label customization for day cell in Calendar component

### DIFF
--- a/src/VueDatePicker/components/Calendar.vue
+++ b/src/VueDatePicker/components/Calendar.vue
@@ -38,6 +38,7 @@
                                     dayVal.classData.dp__range_start
                                 "
                                 :aria-disabled="dayVal.classData.dp__cell_disabled"
+                                :aria-label="ariaLabels.day?.(dayVal)"
                                 tabindex="0"
                                 @click.stop.prevent="$emit('selectDate', dayVal)"
                                 @keydown.enter="$emit('selectDate', dayVal)"

--- a/src/VueDatePicker/interfaces.ts
+++ b/src/VueDatePicker/interfaces.ts
@@ -162,6 +162,7 @@ export interface AreaLabels {
     openMonthsOverlay: string;
     nextMonth: string;
     prevMonth: string;
+    day: (dayVal: ICalendarDay) => string | null;
 }
 
 export interface CalendarRef {

--- a/src/VueDatePicker/utils/util.ts
+++ b/src/VueDatePicker/utils/util.ts
@@ -197,6 +197,7 @@ export const defaultAriaLabels = (labels: Partial<AreaLabels>): AreaLabels => {
             openMonthsOverlay: 'Open months overlay',
             nextMonth: 'Next month',
             prevMonth: 'Previous month',
+            day: () => null,
         },
         labels,
     );


### PR DESCRIPTION
**Why**
  -When navigating inside calendar datagrid, screenreader will announce day cell content, which is a number by default. For screenreader user, we may need to customize day cell text content to announce more info like weekday, or full date (Month-day-year). 

**Existing implementation**
 -Tried slots "day" with aria-label to override inner text content. It works with VoiceOver (mac/iOS), but does not work with  NVDA (windows) default browse mode. 

**Solution**
Extending props ariaLabels by adding an optional "day" function to allow customization. 
Tested VoiceOver and NVDA.

Sample code:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/5761640/195219017-bdb997b5-1d1e-4be2-b777-a1a174c86b26.png">

Generated DOM:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/5761640/195219125-8284ba2f-cb50-488c-960f-0f52125ea10d.png">


**Question**
If this PR is accepted, I'd like to know how to update documentations. I can see they're under docs/api folder. @Jasenkoo 
