### PR TITLE
fix: addEventListener

### DIFF
--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -250,11 +250,11 @@
             menu.addEventListener('pointerdown', stopDefault);
             menu.addEventListener('mousedown', stopDefault);
         }
-        document.addEventListener('resize', getCalendarWidth);
+        window.addEventListener('resize', getCalendarWidth);
     });
 
     onUnmounted(() => {
-        document.removeEventListener('resize', getCalendarWidth);
+        window.removeEventListener('resize', getCalendarWidth);
     });
 
     const { arrowRight, arrowLeft, arrowDown, arrowUp } = useArrowNavigation();


### PR DESCRIPTION
There is no `resize` event on `document` object.
Reference: https://stackoverflow.com/questions/12045440/difference-between-document-addeventlistener-and-window-addeventlistener