### PR TITLE
fix: emit update-month-year event when scrolling over the calendar.

### DIFF
--- a/src/VueDatePicker/components/composables/calendar.ts
+++ b/src/VueDatePicker/components/composables/calendar.ts
@@ -586,6 +586,7 @@ export const useCalendar = (
             if (defaults.value.multiCalendars && !props.multiCalendarsSolo) {
                 autoChangeMultiCalendars(instance);
             }
+            emit('update-month-year', { instance, month: getMonth(date), year: getYear(date) });
             triggerCalendarTransition();
         }
     };


### PR DESCRIPTION
If you change the month manually (via the arrows or selection) the 'update-month-year' it is emitted.
When scrolling the mouse wheel over the calendar, the month will change but the 'update-month-year' event is not emitted.