### PR TITLE
Remove redundant backgrounds

### DIFF
--- a/src/VueDatePicker/style/components/_ActionRow.scss
+++ b/src/VueDatePicker/style/components/_ActionRow.scss
@@ -5,7 +5,6 @@
   padding: $dp__common_padding;
   box-sizing: border-box;
   color: var(--dp-text-color);
-  background: var(--dp-background-color);
 
   svg {
     height: $dp__button_icon_height;

--- a/src/VueDatePicker/style/main.scss
+++ b/src/VueDatePicker/style/main.scss
@@ -81,7 +81,6 @@
   width: 100%;
   text-align: center;
   color: var(--dp-icon-color);
-  background: var(--dp-background-color);
   cursor: pointer;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Remove redundant background colors. Background color is already applied to `.dp__menu`. Removing the background from `.dp__action_row` also resolves the overflow issue which is caused by the border radius:
![image](https://user-images.githubusercontent.com/11559216/221520128-8ceb69b6-e6d3-4c29-91a7-bec9aa07a29f.png)
