### PR TITLE
Fix position of now button - fix #353

### DIFF
--- a/src/VueDatePicker/style/main.scss
+++ b/src/VueDatePicker/style/main.scss
@@ -97,6 +97,11 @@
   box-sizing: border-box;
   height: $dp__button_height;
 
+  &.dp__overlay_action {
+    position: absolute;
+    bottom: 0;
+  }
+
   &:hover {
     background: var(--dp-hover-color);
     color: var(--dp-hover-icon-color);


### PR DESCRIPTION
This will fix position of `now` button in month/year view when teleport-center is active.