### PR TITLE
Fix flexbox value with mixed support

### DIFF
--- a/src/VueDatePicker/style/components/_ActionRow.scss
+++ b/src/VueDatePicker/style/components/_ActionRow.scss
@@ -17,7 +17,7 @@
 .dp__selection_preview {
   display: block;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   flex-basis: 50%;
 
   color: var(--dp-text-color);
@@ -30,7 +30,7 @@
 .dp__action_buttons {
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   flex-basis: 50%;
   text-align: right;
 }

--- a/src/VueDatePicker/style/main.scss
+++ b/src/VueDatePicker/style/main.scss
@@ -125,7 +125,7 @@
 
 .dp__flex_display_with_input {
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .dp__relative {


### PR DESCRIPTION
Closes #361 

Use `flex-start` or `flex-end` as the value of `justify-content` and `align-items` to prevent mixed support on the browser. Especially for **Nuxt** because the bundler configuration for CSS has a strict rule (which is good for us).