### PR TITLE
feat: Allow configuration of six-week mode offset padding

### DIFF
--- a/src/VueDatePicker/interfaces.ts
+++ b/src/VueDatePicker/interfaces.ts
@@ -75,6 +75,8 @@ export type ModelValue =
 export type WeekStartNum = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export type WeekStartStr = '0' | '1' | '2' | '3' | '4' | '5' | '6';
 
+export type SixWeekMode = 'append' | 'prepend' | 'center' | 'fair';
+
 export type MaybeRef<T> = T | Ref<T>;
 export type Fn = () => void;
 

--- a/src/VueDatePicker/utils/props.ts
+++ b/src/VueDatePicker/utils/props.ts
@@ -19,6 +19,7 @@ import type {
     WeekStartNum,
     WeekStartStr,
     CustomAltPosition,
+    SixWeekMode,
 } from '@/interfaces';
 
 export const AllProps = {
@@ -155,7 +156,7 @@ export const AllProps = {
     textInput: { type: Boolean as PropType<boolean>, default: false },
     onClickOutside: { type: Function as PropType<(validate: () => boolean) => void>, default: null },
     noDisabledRange: { type: Boolean as PropType<boolean>, default: false },
-    sixWeeks: { type: Boolean as PropType<boolean>, default: false },
+    sixWeeks: { type: [Boolean, String] as PropType<boolean | SixWeekMode>, default: false },
 };
 
 export type AllPropsType = ExtractPropTypes<typeof AllProps>;


### PR DESCRIPTION
As said in #370, this allows to configure whether additional weeks should be appended (default, old implementation) or prepended, or distributed depending on which weekday the month starts.