### PR TITLE
Export library types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-datepicker.js",
-      "require": "./dist/vue-datepicker.umd.cjs"
+      "require": "./dist/vue-datepicker.umd.cjs",
+      "types": "./index.d.ts"
     },
     "./dist/main.css": {
       "import": "./dist/main.css",


### PR DESCRIPTION
This fixes the following error using TS 5:

```bash
 error TS7016: Could not find a declaration file for module '@vuepic/vue-datepicker'. 'node_modules/.pnpm/@vuepic+vue-datepicker@5.0.0_vue@3.2.47/node_modules/@vuepic/vue-datepicker/dist/vue-datepicker.js' implicitly has an 'any' type.
  There are types at 'node_modules/@vuepic/vue-datepicker/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@vuepic/vue-datepicker' library may need to update its package.json or typings.
```