### PR TITLE
fix(TimePicker): remove forgotten console.log in TimeInput

### DIFF
--- a/src/VueDatePicker/components/TimePicker/TimeInput.vue
+++ b/src/VueDatePicker/components/TimePicker/TimeInput.vue
@@ -253,9 +253,6 @@
             .map((item) => item.value);
 
         return times.filter((item) => {
-            if (type === 'hours') {
-                console.log(!isDateInRange(item, type), item);
-            }
             return !isDateInRange(item, type);
         });
     });


### PR DESCRIPTION
A console.log was forgot in the timeInput.vue