### PR TITLE
Fix VueDatePickerProps interface transitions prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -189,7 +189,7 @@ export interface VueDatePickerProps {
     }[];
     transitions?:
         | boolean
-        | { open?: string; close?: string; next?: string; previous?: string; vNext?: string; vPrevious?: string };
+        | { menuAppear?: string, open?: string; close?: string; next?: string; previous?: string; vNext?: string; vPrevious?: string };
     modeHeight?: string | number;
     enableSeconds?: boolean;
     escClose?: boolean;


### PR DESCRIPTION
VueDatepicker has the typescript error when i try to passing property 'menuAppear' in transitions prop.
I suggest a small fix. Please see my PR.

<img width="757" alt="image" src="https://github.com/Vuepic/vue-datepicker/assets/14171005/fc024e4a-4930-4809-8eac-8e42ea80e393">
