### PR TITLE
feat(global): Adding configuration to support app using @vue/compat

### DIFF
--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -116,6 +116,13 @@
         'range-start',
         'range-end',
     ]);
+
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const props = defineProps({
         ...AllProps,
     });

--- a/src/VueDatePicker/components/ActionRow.vue
+++ b/src/VueDatePicker/components/ActionRow.vue
@@ -73,6 +73,12 @@
     import type { PropType } from 'vue';
     import type { InternalModuleValue } from '@/interfaces';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits(['close-picker', 'select-date', 'select-now', 'invalid-select']);
 
     const props = defineProps({

--- a/src/VueDatePicker/components/Calendar.vue
+++ b/src/VueDatePicker/components/Calendar.vue
@@ -137,6 +137,12 @@
     import type { PropType, UnwrapRef } from 'vue';
     import type { DynamicClass, ICalendarDate, ICalendarDay, IMarker } from '@/interfaces';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits([
         'select-date',
         'set-hover-date',

--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -75,6 +75,12 @@
     import type { PropType } from 'vue';
     import type { DynamicClass } from '@/interfaces';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits([
         'clear',
         'open',

--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -187,6 +187,12 @@
     } from '@/interfaces';
     import type { ComputedRef, PropType, Ref, UnwrapRef } from 'vue';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits([
         'close-picker',
         'select-date',

--- a/src/VueDatePicker/components/Icons/CalendarIcon.ts
+++ b/src/VueDatePicker/components/Icons/CalendarIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -29,3 +29,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/Icons/CancelIcon.ts
+++ b/src/VueDatePicker/components/Icons/CancelIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -23,3 +23,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/Icons/ChevronDownIcon.ts
+++ b/src/VueDatePicker/components/Icons/ChevronDownIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -20,3 +20,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/Icons/ChevronLeftIcon.ts
+++ b/src/VueDatePicker/components/Icons/ChevronLeftIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -20,3 +20,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/Icons/ChevronRightIcon.ts
+++ b/src/VueDatePicker/components/Icons/ChevronRightIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -20,3 +20,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/Icons/ChevronUpIcon.ts
+++ b/src/VueDatePicker/components/Icons/ChevronUpIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -20,3 +20,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/Icons/ClockIcon.ts
+++ b/src/VueDatePicker/components/Icons/ClockIcon.ts
@@ -1,6 +1,6 @@
 import { createElementBlock, createElementVNode, openBlock } from 'vue';
 
-export default function render() {
+function render() {
     return (
         openBlock(),
         createElementBlock(
@@ -23,3 +23,9 @@ export default function render() {
         )
     );
 }
+
+render.compatConfig = {
+    MODE: 3,
+};
+
+export default render;

--- a/src/VueDatePicker/components/MonthYearPicker/ActionIcon.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/ActionIcon.vue
@@ -19,6 +19,12 @@
 <script lang="ts" setup>
     import { onMounted, ref } from 'vue';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits(['activate', 'set-ref']);
 
     interface Props {

--- a/src/VueDatePicker/components/MonthYearPicker/MonthYearPicker.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/MonthYearPicker.vue
@@ -230,6 +230,12 @@
     import type { IDefaultSelect, InternalModuleValue } from '@/interfaces';
     import { getDate } from '@/utils/date-utils';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits(['update-month-year', 'month-year-select', 'mount', 'reset-flow', 'overlay-closed']);
     const props = defineProps({
         month: { type: Number as PropType<number>, default: 0 },

--- a/src/VueDatePicker/components/MonthYearPicker/RegularPicker.vue
+++ b/src/VueDatePicker/components/MonthYearPicker/RegularPicker.vue
@@ -59,6 +59,12 @@
     import type { PropType } from 'vue';
     import type { IDefaultSelect, Transition, AriaLabels, Flow } from '@/interfaces';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits(['update:model-value', 'toggle', 'set-ref']);
     const props = defineProps({
         ariaLabel: { type: String as PropType<string>, default: '' },

--- a/src/VueDatePicker/components/SelectionGrid.vue
+++ b/src/VueDatePicker/components/SelectionGrid.vue
@@ -75,6 +75,12 @@
     import type { IDefaultSelect, DynamicClass, Flow, AriaLabels, InternalModuleValue } from '@/interfaces';
     import type { AllPropsType } from '@/props';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const { setSelectionGrid, buildMultiLevelMatrix, setMonthPicker } = useArrowNavigation();
 
     const emit = defineEmits(['update:model-value', 'selected', 'toggle', 'reset-flow']);

--- a/src/VueDatePicker/components/TimePicker/TimeInput.vue
+++ b/src/VueDatePicker/components/TimePicker/TimeInput.vue
@@ -146,6 +146,12 @@
     import type { Duration } from 'date-fns';
     import type { DynamicClass, IDefaultSelect, TimeType, TimeOverlayCheck } from '@/interfaces';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits([
         'set-hours',
         'set-minutes',

--- a/src/VueDatePicker/components/TimePicker/TimePicker.vue
+++ b/src/VueDatePicker/components/TimePicker/TimePicker.vue
@@ -104,6 +104,12 @@
     import type { PropType } from 'vue';
     import type { TimeInputRef, InternalModuleValue } from '@/interfaces';
 
+    defineOptions({
+        compatConfig: {
+            MODE: 3,
+        }
+    });
+
     const emit = defineEmits([
         'update:hours',
         'update:minutes',


### PR DESCRIPTION
I didn't get app compatible with Vue 2.
But for app in Vue 3 with @vue/compat dependancy some configuration is needed.
I add this configuration for all component and now the datepicker is working nicely.