### PR TITLE
feat(style): support RTL 

### DIFF
--- a/src/VueDatePicker/style/components/_ActionRow.scss
+++ b/src/VueDatePicker/style/components/_ActionRow.scss
@@ -28,7 +28,7 @@
   flex: 0;
   align-items: center;
   justify-content: flex-end;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .dp__action_button {
@@ -36,7 +36,7 @@
   border: 1px solid transparent;
   padding: var(--dp-action-buttons-padding);
   line-height: initial;
-  margin-left: 3px;
+  margin-inline-start: 3px;
   height: var(--dp-action-button-height);
   cursor: pointer;
   border-radius: var(--dp-border-radius);

--- a/src/VueDatePicker/style/components/_Calendar.scss
+++ b/src/VueDatePicker/style/components/_Calendar.scss
@@ -59,13 +59,13 @@
 }
 
 %__dp_range_border_radius_start {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
+  border-end-end-radius: 0;
+  border-start-end-radius: 0;
 }
 
 %__dp_range_border_radius_end {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
+  border-end-start-radius: 0;
+  border-start-start-radius: 0;
 }
 
 %__dp_active {
@@ -159,14 +159,14 @@
   @extend %__dp_range_border_radius_start;
   @extend %__dp_range_preview;
 
-  border-left: 1px dashed var(--dp-primary-color);
+  margin-inline-end: 1px dashed var(--dp-primary-color);
 }
 
 .dp__cell_auto_range_end {
   @extend %__dp_range_border_radius_end;
   @extend %__dp_range_preview;
 
-  border-right: 1px dashed var(--dp-primary-color);
+  border-inline-end: 1px dashed var(--dp-primary-color);
 }
 
 .dp__calendar_header_separator {
@@ -176,7 +176,7 @@
 }
 
 .dp__calendar_next {
-  margin-left: var(--dp-multi-calendars-spacing);
+  margin-inline-start: var(--dp-multi-calendars-spacing);
 }
 
 %__dp_marker {
@@ -230,7 +230,7 @@
   border-radius: 50%;
   background-color: var(--dp-text-color);
   color: var(--dp-text-color);
-  margin-right: 5px;
+  margin-inline-end: 5px;
 }
 
 .dp__arrow_bottom_tp {
@@ -239,7 +239,7 @@
   width: 8px;
   background-color: var(--dp-tooltip-color);
   position: absolute;
-  border-right: 1px solid var(--dp-border-color);
+  border-inline-end: 1px solid var(--dp-border-color);
   border-bottom: 1px solid var(--dp-border-color);
   transform: translate(-50%, 50%) rotate(45deg);
 }

--- a/src/VueDatePicker/style/components/_DatepickerInput.scss
+++ b/src/VueDatePicker/style/components/_DatepickerInput.scss
@@ -64,6 +64,7 @@
   cursor: pointer;
   position: absolute;
   top: 50%;
+  inset-inline-start:0;
   transform: translateY(-50%);
   color: var(--dp-icon-color);
 }
@@ -71,7 +72,7 @@
 .dp__clear_icon {
   position: absolute;
   top: 50%;
-  right: 0;
+  inset-inline-end: 0;
   transform: translateY(-50%);
   cursor: pointer;
   color: var(--dp-icon-color);

--- a/src/VueDatePicker/style/components/_DatepickerInput.scss
+++ b/src/VueDatePicker/style/components/_DatepickerInput.scss
@@ -64,7 +64,6 @@
   cursor: pointer;
   position: absolute;
   top: 50%;
-  left: 0;
   transform: translateY(-50%);
   color: var(--dp-icon-color);
 }
@@ -79,7 +78,7 @@
 }
 
 .dp__input_icon_pad {
-  padding-left: var(--dp-input-icon-padding);
+  padding-inline-start: var(--dp-input-icon-padding);
 }
 
 .dp__input_valid {

--- a/src/VueDatePicker/style/components/_DatepickerMenu.scss
+++ b/src/VueDatePicker/style/components/_DatepickerMenu.scss
@@ -58,7 +58,7 @@
   width: 12px;
   background-color: var(--dp-background-color);
   position: absolute;
-  border-left: 1px solid var(--dp-menu-border-color);
+  border-inline-end: 1px solid var(--dp-menu-border-color);
   border-top: 1px solid var(--dp-menu-border-color);
   transform: translate(-50%, -50%) rotate(45deg);
 }
@@ -70,7 +70,7 @@
   width: 12px;
   background-color: var(--dp-background-color);
   position: absolute;
-  border-right: 1px solid var(--dp-menu-border-color);
+  border-inline-end: 1px solid var(--dp-menu-border-color);
   border-bottom: 1px solid var(--dp-menu-border-color);
   transform: translate(-50%, 50%) rotate(45deg);
 }
@@ -82,17 +82,17 @@
 
 .dp__preset_ranges {
   padding: 5px;
-  border-right: 1px solid var(--dp-border-color);
+  border-inline-end: 1px solid var(--dp-border-color);
 }
 
 .dp__sidebar_left {
   padding: 5px;
-  border-right: 1px solid var(--dp-border-color);
+  border-inline-end: 1px solid var(--dp-border-color);
 }
 
 .dp__sidebar_right {
   padding: 5px;
-  border-left: 1px solid var(--dp-border-color);
+  margin-inline-end: 1px solid var(--dp-border-color);
 }
 
 .dp__preset_range {

--- a/src/VueDatePicker/style/components/_MonthYearInput.scss
+++ b/src/VueDatePicker/style/components/_MonthYearInput.scss
@@ -28,6 +28,10 @@
   }
 }
 
+[dir="rtl"] .dp__inner_nav {
+  transform: rotate(180deg);
+}
+
 %__dp_inner_nav_disabled {
   background: var(--dp-disabled-color);
   color: var(--dp-disabled-color-text);

--- a/src/VueDatePicker/style/components/_SelectionGrid.scss
+++ b/src/VueDatePicker/style/components/_SelectionGrid.scss
@@ -53,8 +53,8 @@
   padding: 0;
   box-sizing: border-box;
   display: flex;
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline-start: auto;
+  margin-inline-end: auto;
   flex-wrap: wrap;
   max-width: 100%;
   width: 100%;


### PR DESCRIPTION
❤️ Thank you @Jasenkoo  for this wonderful package.

This PR introduces support for RTL languages.

Before : 

![image](https://github.com/Vuepic/vue-datepicker/assets/37311945/ec4eb577-9cce-4899-8e82-f729ba622ddf)

After: 

![image](https://github.com/Vuepic/vue-datepicker/assets/37311945/b6fd938a-26e1-43f7-b607-8d17733ad41b)

----- 

I'm wondering why Markdown is not available to edit documents. I need to add an example for `RTL` in `customization.

```vue

<template>
    <div class="wrapper" dir="rtl">
        <Datepicker
            placeholder="اختر التاريخ"
            v-model="date"
            range
            multi-calendars
            locale="ar"
            now-button-label="Current"
            :day-names="['الأحد', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت']"
            :preset-ranges="presetRanges"
            teleport
            select-text="موافق"
            cancel-text="إلغاء"
            :allow-prevent-default="true"
            :enable-time-picker="false"
        />
    </div>
</template>

<script lang="ts" setup>
    import { ref } from 'vue';
    import Datepicker from '../src/VueDatePicker/VueDatePicker.vue';

    const date = ref();
    const today = new Date();
    const yesterday = new Date();

    today.setHours(0, 0, 0, 0);
    yesterday.setDate(today.getDate() - 1);
    yesterday.setHours(0, 0, 0, 0);

    const presetRanges = ref([
        {
            label: 'اليوم',
            range: [today, today],
        },
        {
            label: 'أمس',
            range: [yesterday, yesterday],
        },

        {
            label: 'الشهر الحالي',
            range: [
                new Date(today.getFullYear(), today.getMonth(), 1),
                new Date(today.getFullYear(), today.getMonth(), today.getDate()),
            ],
        },

        {
            label: 'الشهر السابق',
            range: [
                new Date(today.getFullYear(), today.getMonth() - 1, 1),
                new Date(today.getFullYear(), today.getMonth(), 0),
            ],
        },
        {
            label: 'آخر 3 شهور',
            range: [
                new Date(today.getFullYear(), today.getMonth() - 3, 1),
                new Date(today.getFullYear(), today.getMonth(), 0),
            ],
        },
        {
            label: 'آخر 6 أشهر',
            range: [
                new Date(today.getFullYear(), today.getMonth() - 6, 1),
                new Date(today.getFullYear(), today.getMonth(), 0),
            ],
        },
        {
            label: 'السنة الحالية',
            range: [new Date(today.getFullYear(), 0, 1), new Date(today.getFullYear(), 11, 31)],
        },
        {
            label: ' آخر سنتين',
            range: [new Date(today.getFullYear() - 2, 0, 1), new Date(today.getFullYear(), 11, 31)],
        },
        {
            label: ' آخر 3 سنوات',
            range: [new Date(today.getFullYear() - 2, 0, 1), new Date(today.getFullYear(), 11, 31)],
        },
    ]);
</script>

<style lang="scss">
    @import 'src/VueDatePicker/style/main';
    .wrapper {
        padding: 200px;
    }

    .dp__calendar_header_item {
        width: auto !important;
    }
</style>


``` 