### PR TITLE
preset-ranges: Keyboard navigation (tabindex, aria button) + steamlined slot template

### DIFF
--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -32,7 +32,6 @@
                         :key="i"
                         :style="preset.style || {}"
                         class="dp__preset_range"
-                        @click="presetDateRange(preset.range, !!preset.slot)"
                     >
                         <template v-if="preset.slot">
                             <slot
@@ -43,7 +42,13 @@
                             />
                         </template>
                         <template v-else>
-                            {{ preset.label }}
+                            <span
+                                role="button"
+                                tabindex="0"
+                                @click="presetDateRange(preset.range)"
+                                @keydown.enter.prevent="presetDateRange(preset.range)"
+                                @keydown.space.prevent="presetDateRange(preset.range)"
+                            >{{ preset.label }}</span>
                         </template>
                     </div>
                 </div>

--- a/src/VueDatePicker/style/components/_DatepickerMenu.scss
+++ b/src/VueDatePicker/style/components/_DatepickerMenu.scss
@@ -96,7 +96,6 @@
 }
 
 .dp__preset_range {
-  padding: 5px;
   display: block;
   white-space: nowrap;
   color: var(--dp-text-color);
@@ -106,6 +105,11 @@
   &:hover {
     background-color: var(--dp-hover-color);
     cursor: pointer;
+  }
+
+  :first-child {
+    padding: 5px;
+    display: block;
   }
 }
 


### PR DESCRIPTION
**Why this PR?**

In a current project we are using the vue-datepicker because it works very well accessibility-wise. While testing, we discovered that it's **not possible to use the tab navigation to access the configured "preset-ranges"** in the sidebar using the keyboard's tab keys.

**Content of this PR**

This PR contains the updated implementation and the updated documentation for the "preset-ranges". The Documentation can be found in this PR description. (See section "Documentation update")

- Streamlined the syntax of the slot written by the user and the syntax of the default implementation in src/VueDatePicker/components/DatepickerMenu.vue. They now share the same syntax.
- Added arial role button
- Added tabindex
- It's now possible to select a range by "click", but also "enter" or "space" key on the keyboard. (@keydown.enter + @keydown.space)
- Updated CSS to ensure correct padding.
- Documentation
  - Explains the properties in more detail.
  - Code Example: Updated slot implementation + **Slot example** is now clearer because of the slot-name and example.

```html
<template #preset-date-range-button="{ label, range, presetDateRange }">
  <span
    role="button"
    :tabindex="0"
    @click="presetDateRange(range)"
    @keyup.enter.prevent="presetDateRange(range)"
    @keyup.space.prevent="presetDateRange(range)"
  >{{ label }}</span>
</template>
```

# Documentation update

*preset-ranges*

When configured, it will provide a sidebar with configured range that user can select. 

...

```ts
interface PresetRange {
  label: string;
  range: Date[] | string[];
  style?: Record<string, string>;
  slot?: string
}
```

**Properties explanation:**

- label: Label of the button
- range: Array of date objects or strings representing the dates that the user can select.
- style: Array of CSS inline styles, e.g. ['color:red']
- slot: Name of the slot that is used in the custom slot template, e.g. #preset-date-range-button. (See below)

**Code Example**

```vue
<template>
    <VueDatePicker v-model="date" range :preset-ranges="presetRanges">
      <template #preset-date-range-button="{ label, range, presetDateRange }">
        <span
          role="button"
          :tabindex="0"
          @click="presetDateRange(range)"
          @keyup.enter.prevent="presetDateRange(range)"
          @keyup.space.prevent="presetDateRange(range)"
        >{{ label }}</span>
      </template>
    </VueDatePicker>
</template>

<script setup>
import { ref } from 'vue';
import { endOfMonth, endOfYear, startOfMonth, startOfYear, subMonths } from 'date-fns';

const date = ref();

const presetRanges = ref([
  {
    label: 'Today (Slot: preset-date-range-button)',
    range: [new Date(), new Date()],
    slot: 'preset-date-range-button'
  },
  {
    label: 'This month',
    range: [startOfMonth(new Date()), endOfMonth(new Date())]
  },
  {
    label: 'Last month',
    range: [startOfMonth(subMonths(new Date(), 1)), endOfMonth(subMonths(new Date(), 1))],
  },
  {
    label: 'This year',
    range: [startOfYear(new Date()), endOfYear(new Date())]
  },
  {
    label: 'This year (Slot: preset-date-range-button)',
    range: [startOfYear(new Date()), endOfYear(new Date())]
  },
]);
</script>
```