### PR TITLE
fix: Attribute "aria-disabled" with v-bind value `false`...

### DIFF
--- a/src/VueDatePicker/components/Common/ArrowBtn.vue
+++ b/src/VueDatePicker/components/Common/ArrowBtn.vue
@@ -7,7 +7,7 @@
         @keydown.space.prevent="$emit('activate')"
         tabindex="0"
         :aria-label="ariaLabel"
-        :aria-disabled="disabled"
+        :aria-disabled="disabled || undefined"
         ref="elRef"
     >
         <span class="dp__inner_nav" :class="{ dp__inner_nav_disabled: disabled }">

--- a/src/VueDatePicker/components/Common/SelectionOverlay.vue
+++ b/src/VueDatePicker/components/Common/SelectionOverlay.vue
@@ -30,7 +30,7 @@
                         :class="cellClassName"
                         :key="col.value"
                         :aria-selected="col.active"
-                        :aria-disabled="col.disabled"
+                        :aria-disabled="col.disabled || undefined"
                         :ref="(el) => assignRef(el, col, i, ind)"
                         tabindex="0"
                         :data-test="col.text"

--- a/src/VueDatePicker/components/DatePicker/DpCalendar.vue
+++ b/src/VueDatePicker/components/DatePicker/DpCalendar.vue
@@ -29,7 +29,7 @@
                     <div
                         class="dp__calendar"
                         role="grid"
-                        :aria-label="defaultedAriaLabels?.calendarDays"
+                        :aria-label="defaultedAriaLabels?.calendarDays || undefined"
                         v-if="showCalendar"
                     >
                         <div
@@ -54,7 +54,7 @@
                                     dayVal.classData.dp__range_start ||
                                     dayVal.classData.dp__range_start
                                 "
-                                :aria-disabled="dayVal.classData.dp__cell_disabled"
+                                :aria-disabled="dayVal.classData.dp__cell_disabled || undefined"
                                 :aria-label="defaultedAriaLabels?.day?.(dayVal)"
                                 tabindex="0"
                                 :data-test="dayVal.value"


### PR DESCRIPTION
Attribute "aria-disabled" with v-bind value `false` will render aria-disabled="false" instead of removing it in Vue 3. remove the attribute, use `null` or `undefined` instead. If the usage is intended, you can disable the compat behavior and suppress this warning with:

configureCompat({ ATTR_FALSE_VALUE: false })

Details: https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html at <ArrowBtn key=0 aria-label="Previous month" disabled=false  ... > at <DpHeader key=0 ref=fn<ref> months= (12) [{…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}]  ... > at <InstanceWrap multi-calendars=0 >
at <DatePicker ref_key="dynCmpRef" ref=Ref< null > multiCalendars=undefined  ... > at <DatepickerMenu multiCalendars=undefined modelValue= Fri Aug 18 2023 10:41:40 GMT-0500 (Central Daylight Time) modelType=null  ... >