### PR TITLE
fix: prev val is set when auto-apply & text-input

### DIFF
--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -280,6 +280,7 @@
     const clearValue = (): void => {
         inputValue.value = '';
         clearInternalValues();
+        inputRef.value?.setParsedDate(null);
         emit('update:model-value', null);
         emit('update:model-timezone-value', null);
         emit('cleared');

--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -275,7 +275,7 @@
         inputRef.value?.focus({ preventScroll: true });
     };
 
-    const setParsedDate = (date: Date) => {
+    const setParsedDate = (date: Date | null) => {
         parsedDate.value = date;
     };
 

--- a/src/VueDatePicker/interfaces.ts
+++ b/src/VueDatePicker/interfaces.ts
@@ -193,7 +193,7 @@ export type DatepickerMenuRef = ComponentPublicInstance<{
 }>;
 
 export type DatepickerInputRef = ComponentPublicInstance<{
-    setParsedDate: (date: Date | Date[]) => void;
+    setParsedDate: (date: Date | Date[]| null) => void;
     focusInput: () => void;
 }>;
 


### PR DESCRIPTION
Fixed the bugs listed below.

1. auto-apply and text-input
2. input DateTime
3. click clear button
4. focus input and open Menu（no input）
5. click outside and close Menu
6. prev inputed DateTime is set

replication：[https://stackblitz.com/edit/nuxt-starter-tdp8cr?file=app.vue](https://stackblitz.com/edit/nuxt-starter-tdp8cr?file=app.vue
)