### PR TITLE
fix: Add null type to updateInternalModelValue parameter types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -294,7 +294,7 @@ export interface PublicMethods extends MethodOptions {
     openMenu: () => void;
     clearValue: () => void;
     onScroll: () => void;
-    updateInternalModelValue: (value: Date | Date[]) => void;
+    updateInternalModelValue: (value: Date | Date[] | null) => void;
     setMonthYear: (value: { month?: number | string; year?: number | string }) => void;
     parseModel: (value?: ModelValue) => void;
     switchView: (view: MenuView, instance?: number) => void;


### PR DESCRIPTION
Sometimes we need to reset internalModelValue by setting it to `null` in `updateInternalModelValue` public method. This PR fixes incoming parameter type.