### PR TITLE
fix: Incorrect aria role

### DIFF
--- a/src/VueDatePicker/components/DatePicker/DpCalendar.vue
+++ b/src/VueDatePicker/components/DatePicker/DpCalendar.vue
@@ -28,7 +28,7 @@
                 <transition :name="transitionName" :css="!!transitions">
                     <div
                         class="dp__calendar"
-                        role="grid"
+                        role="rowgroup"
                         :aria-label="defaultedAriaLabels?.calendarDays || undefined"
                         v-if="showCalendar"
                     >


### PR DESCRIPTION
The calendar currently has nested grid role, this causes an [aria-required-children](https://accessibilityinsights.io/info-examples/web/aria-required-children/) error. I have replaced the nested `grid` with a `rowgroup`.