### PR TITLE
Use explicit import for date-fns to improve treeshaking

### DIFF
--- a/src/VueDatePicker/components/DatePicker/DpCalendar.vue
+++ b/src/VueDatePicker/components/DatePicker/DpCalendar.vue
@@ -131,7 +131,8 @@
 
 <script lang="ts" setup>
     import { computed, nextTick, onMounted, ref } from 'vue';
-    import { getISOWeek, getWeek } from 'date-fns';
+    import getISOWeek from 'date-fns/getISOWeek';
+    import getWeek from 'date-fns/getWeek';
 
     import { checkStopPropagation, getDayNames, getDefaultMarker, unrefElement } from '@/utils/util';
     import { useArrowNavigation, useDefaults } from '@/composables';

--- a/src/VueDatePicker/components/DatePicker/date-picker.ts
+++ b/src/VueDatePicker/components/DatePicker/date-picker.ts
@@ -1,17 +1,15 @@
 import { computed, onMounted, ref, nextTick, watch } from 'vue';
-import {
-    add,
-    addDays,
-    addMonths,
-    getHours,
-    getMinutes,
-    getMonth,
-    getSeconds,
-    getYear,
-    set,
-    startOfWeek,
-    subMonths,
-} from 'date-fns';
+import add from 'date-fns/add';
+import addDays from 'date-fns/addDays';
+import addMonths from 'date-fns/addMonths';
+import getHours from 'date-fns/getHours';
+import getMinutes from 'date-fns/getMinutes';
+import getMonth from 'date-fns/getMonth';
+import getSeconds from 'date-fns/getSeconds';
+import getYear from 'date-fns/getYear';
+import set from 'date-fns/set';
+import startOfWeek from 'date-fns/startOfWeek';
+import subMonths from 'date-fns/subMonths';
 
 import {
     getDate,

--- a/src/VueDatePicker/components/MonthPicker/month-picker.ts
+++ b/src/VueDatePicker/components/MonthPicker/month-picker.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
-import { getMonth, getYear } from 'date-fns';
+import getMonth from 'date-fns/getMonth';
+import getYear from 'date-fns/getYear';
 
 import { checkMinMaxValue, getMonths, groupListAndMap } from '@/utils/util';
 import {

--- a/src/VueDatePicker/components/QuarterPicker/quarter-picker.ts
+++ b/src/VueDatePicker/components/QuarterPicker/quarter-picker.ts
@@ -1,17 +1,15 @@
 import { computed, ref } from 'vue';
-import {
-    eachQuarterOfInterval,
-    endOfQuarter,
-    endOfYear,
-    format,
-    getMonth,
-    getQuarter,
-    getYear,
-    isSameQuarter,
-    set,
-    startOfQuarter,
-    startOfYear,
-} from 'date-fns';
+import eachQuarterOfInterval from 'date-fns/eachQuarterOfInterval';
+import endOfQuarter from 'date-fns/endOfQuarter';
+import endOfYear from 'date-fns/endOfYear';
+import format from 'date-fns/format';
+import getMonth from 'date-fns/getMonth';
+import getQuarter from 'date-fns/getQuarter';
+import getYear from 'date-fns/getYear';
+import isSameQuarter from 'date-fns/isSameQuarter';
+import set from 'date-fns/set';
+import startOfQuarter from 'date-fns/startOfQuarter';
+import startOfYear from 'date-fns/startOfYear';
 
 import { useDefaults, useModel, useValidation } from '@/composables';
 import { useMonthOrQuarterPicker } from '@/components/shared/month-quarter-picker';

--- a/src/VueDatePicker/components/TimePicker/TimeInput.vue
+++ b/src/VueDatePicker/components/TimePicker/TimeInput.vue
@@ -130,7 +130,15 @@
 
 <script lang="ts" setup>
     import { computed, onMounted, reactive, ref } from 'vue';
-    import { add, getHours, getMinutes, getSeconds, isAfter, isBefore, isEqual, set, sub } from 'date-fns';
+    import add from 'date-fns/add';
+    import getHours from 'date-fns/getHours';
+    import getMinutes from 'date-fns/getMinutes';
+    import getSeconds from 'date-fns/getSeconds';
+    import isAfter from 'date-fns/isAfter';
+    import isBefore from 'date-fns/isBefore';
+    import isEqual from 'date-fns/isEqual';
+    import set from 'date-fns/set';
+    import sub from 'date-fns/sub';
 
     import { ChevronUpIcon, ChevronDownIcon, ClockIcon } from '@/components/Icons';
     import SelectionOverlay from '@/components/Common/SelectionOverlay.vue';

--- a/src/VueDatePicker/components/TimePicker/time-picker-utils.ts
+++ b/src/VueDatePicker/components/TimePicker/time-picker-utils.ts
@@ -1,6 +1,9 @@
 import { computed } from 'vue';
 
-import { isAfter, isBefore, setMilliseconds, setSeconds } from 'date-fns';
+import isAfter from 'date-fns/isAfter';
+import isBefore from 'date-fns/isBefore';
+import setMilliseconds from 'date-fns/setMilliseconds';
+import setSeconds from 'date-fns/setSeconds';
 
 import { getDate, isDateEqual, setDateTime } from '@/utils/date-utils';
 

--- a/src/VueDatePicker/components/TimePicker/time-picker.ts
+++ b/src/VueDatePicker/components/TimePicker/time-picker.ts
@@ -1,5 +1,5 @@
 import { onMounted } from 'vue';
-import { set } from 'date-fns';
+import set from 'date-fns/set';
 
 import { useDefaults, useModel } from '@/composables';
 import { useTimePickerUtils } from '@/components/TimePicker/time-picker-utils';

--- a/src/VueDatePicker/components/YearPicker/year-picker.ts
+++ b/src/VueDatePicker/components/YearPicker/year-picker.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
-import { getYear, setYear } from 'date-fns';
+import getYear from 'date-fns/getYear';
+import setYear from 'date-fns/setYear';
 
 import { useDefaults, useModel } from '@/composables';
 import { checkMinMaxValue, getYears, groupListAndMap } from '@/utils/util';

--- a/src/VueDatePicker/components/shared/month-quarter-picker.ts
+++ b/src/VueDatePicker/components/shared/month-quarter-picker.ts
@@ -1,5 +1,9 @@
 import { computed, onMounted, ref } from 'vue';
-import { addYears, getMonth, getYear, set, subYears } from 'date-fns';
+import addYears from 'date-fns/addYears';
+import getMonth from 'date-fns/getMonth';
+import getYear from 'date-fns/getYear';
+import set from 'date-fns/set';
+import subYears from 'date-fns/subYears';
 
 import { checkHighlightYear, getDate, getMinMaxYear, resetDate, validateMonthYear } from '@/utils/date-utils';
 import { checkMinMaxValue, getYears, groupListAndMap } from '@/utils/util';

--- a/src/VueDatePicker/composables/calendar-class.ts
+++ b/src/VueDatePicker/composables/calendar-class.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { addDays } from 'date-fns';
+import addDays from 'date-fns/addDays';
 
 import { useDefaults, useValidation } from '@/composables/index';
 import { isModelAuto } from '@/utils/util';

--- a/src/VueDatePicker/composables/external-internal-mapper.ts
+++ b/src/VueDatePicker/composables/external-internal-mapper.ts
@@ -1,5 +1,12 @@
 import { ref, toRef, watch } from 'vue';
-import { format, getHours, getMinutes, getMonth, getSeconds, getYear, parse, setYear } from 'date-fns';
+import format from 'date-fns/format';
+import getHours from 'date-fns/getHours';
+import getMinutes from 'date-fns/getMinutes';
+import getMonth from 'date-fns/getMonth';
+import getSeconds from 'date-fns/getSeconds';
+import getYear from 'date-fns/getYear';
+import parse from 'date-fns/parse';
+import setYear from 'date-fns/setYear';
 
 import {
     checkPartialRangeValue,

--- a/src/VueDatePicker/composables/model.ts
+++ b/src/VueDatePicker/composables/model.ts
@@ -1,5 +1,8 @@
 import { computed, ref, reactive } from 'vue';
-import { getHours, getMinutes, getMonth, getYear } from 'date-fns';
+import getHours from 'date-fns/getHours';
+import getMinutes from 'date-fns/getMinutes';
+import getMonth from 'date-fns/getMonth';
+import getYear from 'date-fns/getYear';
 
 import { getDate, getZonedDate } from '@/utils/date-utils';
 

--- a/src/VueDatePicker/composables/month-year.ts
+++ b/src/VueDatePicker/composables/month-year.ts
@@ -1,5 +1,12 @@
 import { computed } from 'vue';
-import { addMonths, addYears, getMonth, getYear, set, setYear, subMonths, subYears } from 'date-fns';
+import addMonths from 'date-fns/addMonths';
+import addYears from 'date-fns/addYears';
+import getMonth from 'date-fns/getMonth';
+import getYear from 'date-fns/getYear';
+import set from 'date-fns/set';
+import setYear from 'date-fns/setYear';
+import subMonths from 'date-fns/subMonths';
+import subYears from 'date-fns/subYears';
 
 import { useDefaults, useValidation } from '@/composables/index';
 import { validateMonthYear } from '@/utils/date-utils';

--- a/src/VueDatePicker/composables/validation.ts
+++ b/src/VueDatePicker/composables/validation.ts
@@ -1,4 +1,10 @@
-import { differenceInCalendarDays, eachDayOfInterval, getDay, getHours, getMinutes, getMonth, getYear } from 'date-fns';
+import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
+import eachDayOfInterval from 'date-fns/eachDayOfInterval';
+import getDay from 'date-fns/getDay';
+import getHours from 'date-fns/getHours';
+import getMinutes from 'date-fns/getMinutes';
+import getMonth from 'date-fns/getMonth';
+import getYear from 'date-fns/getYear';
 import {
     checkTimeMinMax,
     getDate,

--- a/src/VueDatePicker/utils/date-utils.ts
+++ b/src/VueDatePicker/utils/date-utils.ts
@@ -1,31 +1,30 @@
-import {
-    parse,
-    isDate,
-    isValid,
-    setHours,
-    setMinutes,
-    setSeconds,
-    setMilliseconds,
-    isBefore,
-    isEqual,
-    isAfter,
-    set,
-    getHours,
-    getMinutes,
-    getSeconds,
-    getYear,
-    getMonth,
-    parseISO,
-    eachDayOfInterval,
-    addMonths,
-    startOfWeek,
-    endOfWeek,
-    setMonth,
-    setYear,
-    subMonths,
-    format,
-} from 'date-fns';
-import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz/esm';
+import parse from 'date-fns/parse';
+import isDate from 'date-fns/isDate';
+import isValid from 'date-fns/isValid';
+import setHours from 'date-fns/setHours';
+import setMinutes from 'date-fns/setMinutes';
+import setSeconds from 'date-fns/setSeconds';
+import setMilliseconds from 'date-fns/setMilliseconds';
+import isBefore from 'date-fns/isBefore';
+import isEqual from 'date-fns/isEqual';
+import isAfter from 'date-fns/isAfter';
+import set from 'date-fns/set';
+import getHours from 'date-fns/getHours';
+import getMinutes from 'date-fns/getMinutes';
+import getSeconds from 'date-fns/getSeconds';
+import getYear from 'date-fns/getYear';
+import getMonth from 'date-fns/getMonth';
+import parseISO from 'date-fns/parseISO';
+import eachDayOfInterval from 'date-fns/eachDayOfInterval';
+import addMonths from 'date-fns/addMonths';
+import startOfWeek from 'date-fns/startOfWeek';
+import endOfWeek from 'date-fns/endOfWeek';
+import setMonth from 'date-fns/setMonth';
+import setYear from 'date-fns/setYear';
+import subMonths from 'date-fns/subMonths';
+import format from 'date-fns/format';
+import utcToZonedTime from 'date-fns-tz/esm/utcToZonedTime';
+import zonedTimeToUtc from 'date-fns-tz/esm/zonedTimeToUtc';
 import { errors } from '@/utils/util';
 
 import type {

--- a/src/VueDatePicker/utils/util.ts
+++ b/src/VueDatePicker/utils/util.ts
@@ -1,5 +1,5 @@
 import { unref } from 'vue';
-import { format } from 'date-fns';
+import format from 'date-fns/format';
 
 import type { Config, IDefaultSelect, IMarker, MaybeElementRef, ModelValue, OverlayGridItem } from '@/interfaces';
 import type { ComponentPublicInstance } from 'vue';


### PR DESCRIPTION
While `date-fns` support [tree-shaking out-of-the-box](https://date-fns.org/v2.30.0/docs/ECMAScript-Modules), importing from the root of the module (`import { ... } from 'date-fns'`) still require parsing every file of  `date-fns`.

The PR reduce the amount of files parsed
 - ES and UMD: **-31** files
 - IIFE: **-298** files

It also results into a smaller package
 - ES: **-101.42 kB** (-35%) and **16.99 kB** (-27%) compressed
 - UMD: **-67.87 kB** (-32%) and **14.49 kB** (-27%) compressed
 - IIFE: **-3 kB** (-0.01%) and **0.56 kB** (-1%) compressed

```diff
 $ npm run build

 > cross-env NODE_ENV=production vite build --mode production
 
 vite v4.4.11 building for production...
-✓ 234 modules transformed.
-dist/vue-datepicker.js  288.53 kB │ gzip: 63.29 kB
-dist/vue-datepicker.umd.cjs  209.02 kB │ gzip: 54.16 kB
-✓ built in 1.25s
+✓ 203 modules transformed.
+dist/vue-datepicker.js  187.11 kB │ gzip: 46.30 kB
+dist/vue-datepicker.umd.cjs  141.15 kB │ gzip: 39.67 kB
+✓ built in 1.09s
 
 > @vuepic/vue-datepicker@7.2.0 build:browser
 > cross-env NODE_ENV=production vite -f iife build --mode production
 
 vite v4.4.11 building for production...
-✓ 234 modules transformed.
-dist/vue-datepicker.iife.js  208.81 kB │ gzip: 54.08 kB
-✓ built in 1.16s
+✓ 532 modules transformed.
+dist/vue-datepicker.iife.js  208.78 kB │ gzip: 53.52 kB
+✓ built in 1.68s
 
 > @vuepic/vue-datepicker@7.2.0 build:css
 > cross-env NODE_ENV=production node_modules/.bin/sass src/VueDatePicker/style/main.scss dist/main.css --style compressed
```

---

Linked issues:
 - #479
 - #587