### PR TITLE
Update vite config to works with explicit import

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,12 +42,13 @@ export default defineConfig({
             fileName: 'vue-datepicker',
         },
         rollupOptions: {
-            external: f === 'iife' ? ['vue'] : ['vue', 'date-fns', 'date-fns-tz'],
+            external: f === 'iife' ? /^vue$/ : /^(vue$|date-fns\/|date-fns-tz\/)/,
             output: {
-                globals: {
-                    vue: 'Vue',
-                    'date-fns': 'dateFns',
-                    'date-fns-tz': 'dateFnsTz',
+                globals: (name) => {
+                    if (name === "vue") return "Vue"
+                    if (name.startsWith('date-fns/')) return "dateFns" + name.substring(9)
+                    if (name.startsWith('date-fns-tz/')) return "dateFnsTs" + name.substring(12)
+                    return name
                 },
             },
         },


### PR DESCRIPTION
```diff
 $ npm run build

...

 > cross-env NODE_ENV=production vite build --mode production
 
 vite v4.4.11 building for production...
-✓ 203 modules transformed.
-dist/vue-datepicker.js  187.11 kB │ gzip: 46.30 kB
-dist/vue-datepicker.umd.cjs  141.15 kB │ gzip: 39.67 kB
-✓ built in 1.09s
+✓ 74 modules transformed.
+dist/vue-datepicker.js  176.66 kB │ gzip: 43.28 kB
+dist/vue-datepicker.umd.cjs  134.50 kB │ gzip: 37.37 kB
+✓ built in 854ms
 
 > @vuepic/vue-datepicker@7.2.0 build:browser
 > cross-env NODE_ENV=production vite -f iife build --mode production
 
 vite v4.4.11 building for production...
-✓ 532 modules transformed.
-dist/vue-datepicker.iife.js  208.78 kB │ gzip: 53.52 kB
-✓ built in 1.68s
+✓ 234 modules transformed.
+dist/vue-datepicker.iife.js  208.81 kB │ gzip: 54.08 kB
+✓ built in 1.16s

 > @vuepic/vue-datepicker@7.2.0 build:css
 > cross-env NODE_ENV=production node_modules/.bin/sass src/VueDatePicker/style/main.scss dist/main.css --style compressed
```

Comparing with `53d03995cf893be0a991f7bdbcffe6ec7953985d` (in red) with this version (in green)

- Fewer modules parsed in all format (about half)
- Files size have lowered a bit in UMD and ES
- Build time have reduced a bit to 

----

This is a continuation of #626 