### PR TITLE
Changed debounce on month-change-on-scroll to a variable rate throttle

### DIFF
--- a/src/VueDatePicker/components/DatePicker/date-picker.ts
+++ b/src/VueDatePicker/components/DatePicker/date-picker.ts
@@ -27,7 +27,6 @@ import {
     setDateTime,
 } from '@/utils/date-utils';
 import { useDefaults, useModel, useValidation } from '@/composables';
-import { debounce, isNumNullish } from '@/utils/util';
 import { isNumberArray } from '@/utils/type-guard';
 import { useTimePickerUtils } from '@/components/TimePicker/time-picker-utils';
 import { checkRangeAutoApply, handleMultiDatesSelect, setPresetDate } from '@/composables/shared';
@@ -260,11 +259,20 @@ export const useDatePicker = (
     };
 
     // Handle mouse scroll
-    const handleScroll = debounce((event: WheelEvent, instance: number): void => {
+    let lastScrollTime = new Date()
+    const handleScroll = (event: WheelEvent, instance: number): void => {
         if (props.monthChangeOnScroll) {
-            autoChangeMonth(props.monthChangeOnScroll !== 'inverse' ? -event.deltaY : event.deltaY, instance);
+            const timeDelta: number = new Date().getTime() - lastScrollTime.getTime();
+            const scrollDistance = Math.abs(event.deltaY)
+            let minPause: number = 500;
+            if (scrollDistance > 1) minPause = 100;
+            if (scrollDistance > 100) minPause = 0;
+            if (timeDelta > minPause) {
+                lastScrollTime = new Date()
+                autoChangeMonth(props.monthChangeOnScroll !== 'inverse' ? -event.deltaY : event.deltaY, instance);
+            }
         }
-    }, 50);
+    };
 
     // Handle arrow key
     const handleArrow = (arrow: 'left' | 'right', instance: number, vertical = false): void => {


### PR DESCRIPTION
This is an improved implementation of the issue that was resolved here: https://github.com/Vuepic/vue-datepicker/issues/671

The original debounce approach does inhibit uncontrollable scrolling through months, but it also makes the calendar feel extremely sluggish when using a Mac touchpad, as it must wait until the scrolling has completely finished/resolved before the month will change. Rather than using a debounce, throttling the scroll behavior provides a much more responsive experience. 

A flat rate throttle of 1 effective scroll/month change every 100ms provides a good overall experience. But it can be still be touchy for small changes, and also feel slightly sluggish when scrolling rapidly. This implementation includes a variable rate throttle to ensure more control and precision when scrolling lightly, while allowing months to change more quickly when scrolling aggressively.

UX tested on Mac (touchpad and mouse) PC (touchpad and mouse). Regression tested on physical iOS and Android devices. 