### PR TITLE
fix(ExternalInternalMapper): Take format-locale as locale when parsing date

### DIFF
--- a/src/VueDatePicker/composables/external-internal-mapper.ts
+++ b/src/VueDatePicker/composables/external-internal-mapper.ts
@@ -31,6 +31,7 @@ export const useExternalInternalMapper = (emit: VueEmit, props: AllPropsType, is
 
     const inputValue = ref('');
     const formatRef = toRef(props, 'format');
+    const formatLocale = toRef(props, 'formatLocale');
 
     watch(
         internalModelValue,
@@ -312,9 +313,9 @@ export const useExternalInternalMapper = (emit: VueEmit, props: AllPropsType, is
             if (props.modelType === 'date' || props.modelType === 'timestamp') return convertModelToTz(new Date(value));
 
             if (props.modelType === 'format' && (typeof props.format === 'string' || !props.format))
-                return convertModelToTz(parse(value as string, getDefaultPattern(), new Date()));
+                return convertModelToTz(parse(value as string, getDefaultPattern(), new Date(), { locale: formatLocale.value }));
 
-            return convertModelToTz(parse(value as string, props.modelType, new Date()));
+            return convertModelToTz(parse(value as string, props.modelType, new Date(), { locale: formatLocale.value }));
         }
 
         return convertModelToTz(new Date(value));


### PR DESCRIPTION
I found if I use P as format and model-type and fr as format-locale then when I select a date then the month and day switch each other.
That's because day and month aren't in the same order in french and in english.