### PR TITLE
fix: change teleport prop type order to fix boolean casting

### DIFF
--- a/src/VueDatePicker/props.ts
+++ b/src/VueDatePicker/props.ts
@@ -91,7 +91,7 @@ export const AllProps = {
         type: [Function, Object] as PropType<HighlightProp>,
         default: null,
     },
-    teleport: { type: [String, Boolean, Object] as PropType<string | boolean | HTMLElement>, default: null },
+    teleport: { type: [Boolean, String, Object] as PropType<boolean | string | HTMLElement>, default: null },
     teleportCenter: { type: Boolean as PropType<boolean>, default: false },
     locale: { type: String as PropType<string>, default: 'en-Us' },
     weekNumName: { type: String as PropType<string>, default: 'W' },


### PR DESCRIPTION
This pull request addresses an issue with the `teleport` prop where it was not working correctly when passed as a boolean attribute without a value (e.g., `<Datepicker teleport />`).

![image](https://github.com/Vuepic/vue-datepicker/assets/3358193/ebb591a6-5380-4426-9475-ddfaf9e60e6a)

This behavior was caused by the boolean casting rules in Vue 3, as described in the documentation: https://vuejs.org/guide/components/props.html#boolean-casting

By moving `Boolean` before `String` in the type array, the boolean casting rules are applied correctly, allowing the `teleport` prop to work as expected when used as a boolean attribute.

```js
teleport: { type: [Boolean, String, Object] as PropType<boolean | string | HTMLElement>, default: null },
```