### PR TITLE
fix: fix timezone issues for getMonths function

### DIFF
--- a/src/VueDatePicker/utils/util.ts
+++ b/src/VueDatePicker/utils/util.ts
@@ -25,15 +25,15 @@ export const getArrayInArray = <T>(list: T[], increment = 3): T[][] => {
 
 function dayNameIntlMapper(locale: string) {
     return (day: number) => {
-        return new Intl.DateTimeFormat(locale, { weekday: 'short', timeZone: 'UTC' })
-            .format(new Date(`2017-01-0${day}T00:00:00+00:00`))
+        return new Intl.DateTimeFormat(locale, { weekday: 'short' })
+            .format(new Date(`2017-01-0${day}T00:00:00`))
             .slice(0, 2);
     };
 }
 
 function dayNameDateFnsMapper(formatLocale: Locale) {
     return (day: number) => {
-        return format(new Date(`2017-01-0${day}T00:00:00+00:00`), 'EEEEEE', { locale: formatLocale });
+        return format(new Date(`2017-01-0${day}T00:00:00`), 'EEEEEE', { locale: formatLocale });
     };
 }
 
@@ -86,7 +86,7 @@ export const getMonths = (
 ): IDefaultSelect[] => {
     const months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((month) => {
         const mm = month < 10 ? `0${month}` : month;
-        return new Date(`2017-${mm}-01T00:00:00+00:00`);
+        return new Date(`2017-${mm}-01T00:00:00`);
     });
 
     if (formatLocale !== null) {
@@ -104,7 +104,7 @@ export const getMonths = (
         }
     }
 
-    const formatter = new Intl.DateTimeFormat(locale, { month: monthFormat, timeZone: 'UTC' });
+    const formatter = new Intl.DateTimeFormat(locale, { month: monthFormat });
     return months.map((date, i) => {
         const month = formatter.format(date);
         return {

--- a/tests/unit/timezone.spec.ts
+++ b/tests/unit/timezone.spec.ts
@@ -11,7 +11,9 @@ describe('Timezone functionality', () => {
         const offset = getOffset(local);
         const zoned = localToTz(local, 'UTC');
 
-        expect(differenceInHours(local, zoned)).toEqual(offset);
+        const diff = Math.abs(differenceInHours(local, zoned, { roundingMethod: 'round' }));
+
+        expect(diff).toEqual(offset);
     });
 
     it('Should map date to a timezone depending on the timezone config', () => {
@@ -20,7 +22,10 @@ describe('Timezone functionality', () => {
         const utcExact = new Date(getYear(today), 0, 15, 1, 0, 0, 0);
         const offset = getOffset(today);
         const dateInTz = sanitizeDateToLocal(today, { timezone: 'UTC', exactMatch: false });
-        expect(differenceInHours(today, dateInTz as Date)).toEqual(offset);
+
+        const diff = Math.abs(differenceInHours(today, dateInTz as Date, { roundingMethod: 'round' }));
+
+        expect(diff).toEqual(offset);
 
         const dateExact = sanitizeDateToLocal(utc, {
             timezone: 'UTC',


### PR DESCRIPTION
This pull request addresses issue #817

The date used to map the array of month numbers should not have explicitly set timezone in its ISO 8601 string, because in timezones like `America/Sao_Paulo` which has a negative offset of `-3` hours, all dates will be computed one day earlier, eg: `Sat Dec 31 2016 22:00:00 GMT-0200 (Horário de Verão de Brasília)`

This will make the array of months to be something like: `['December', 'January', 'February', ..., 'November']`, making a buggy behaviour in `DatePicker` and `MonthPicker` components.

I think the best way is to remove the timezone from the string and the timezone from the `Intl.DateTimeFormat` constructor, thus defaulting to the system timezone.

Also as I was running the tests in a negative offset, I made some adjustments to the `timezone.spec.ts` tests.