### PR TITLE
feat(month-picker): adds the month-overlay-value slot to the MonthPicker component

### DIFF
--- a/src/VueDatePicker/components/MonthPicker/MonthPicker.vue
+++ b/src/VueDatePicker/components/MonthPicker/MonthPicker.vue
@@ -45,6 +45,9 @@
                         </template>
                     </YearModePicker>
                 </template>
+                <template v-if="$slots['month-overlay-value']" #item="{ item }">
+                    <slot name="month-overlay-value" :text="item.text" :value="item.value" />
+                </template>
             </SelectionOverlay>
         </template>
     </InstanceWrap>


### PR DESCRIPTION
This PR addresses issue #821

Adds the `month-overlay-value` slot to the `MonthPicker` component, which is internally used in the `month-picker` mode, allowing to customize just the month value without the need of resorting to the `month-year` slot.