### PR TITLE
fix: Add safe navigation to arrow position calculation

### DIFF
--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -249,8 +249,8 @@
         if (defaultedConfig.value.arrowLeft) return defaultedConfig.value.arrowLeft;
         const menuRect = dpMenuRef.value?.getBoundingClientRect();
         const inputRect = props.getInputRect();
-        if (inputRect.width < calendarWidth.value && inputRect.left <= (menuRect?.left ?? 0)) {
-            return `${inputRect.width / 2}px`;
+        if (inputRect?.width < calendarWidth?.value && inputRect?.left <= (menuRect?.left ?? 0)) {
+            return `${inputRect?.width / 2}px`;
         }
         return '50%';
     });


### PR DESCRIPTION
This pull request addresses an issue with the `arrowPos` calculation that throws a null reference error if the `inputRect` is undefined. This can happen when using the `inline` mode of the date picker. 

I can't reproduce this in an isolated environment (e.g. jsfiddle) but it happens every time in our project. We've added a temporary work around with `:config="{ arrowLeft: '0px' }"`.

Ideally, this computed calculation should not even need to run when in `inline` mode, but safe navigating inside it is also a viable solution to handle this issue.