### PR TITLE
fix: Wrong weekday names when using `format-locale` in overridden timezone

### DIFF
--- a/src/VueDatePicker/utils/util.ts
+++ b/src/VueDatePicker/utils/util.ts
@@ -35,7 +35,7 @@ function dayNameIntlMapper(locale: string) {
 
 function dayNameDateFnsMapper(formatLocale: Locale) {
     return (day: number) => {
-        return format(new Date(`2017-01-0${day}T00:00:00+00:00`), 'EEEEEE', { locale: formatLocale });
+        return format(localToTz(new Date(`2017-01-0${day}T00:00:00+00:00`), 'UTC'), 'EEEEEE', { locale: formatLocale });
     };
 }
 

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -169,7 +169,7 @@ describe('Utils and date utils formatting', () => {
     });
 
     it('Should get short month values by fallback to locale', () => {
-        // Pass incorrect formatLocale
+        // @ts-expect-error Pass incorrect formatLocale
         const months = getMonths({}, 'de', 'short');
 
         expect(months).toHaveLength(12);

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -122,26 +122,60 @@ describe('Utils and date utils formatting', () => {
         expect(years[1].value).toEqual(2022);
     });
 
-    it('Should get month values according to locale', () => {
+    it('Should get long month values according to locale', () => {
         const months = getMonths(null, 'en', 'long');
 
         expect(months).toHaveLength(12);
         expect(months[0].text).toEqual('January');
+        expect(months[1].text).toEqual('February');
+        expect(months[2].text).toEqual('March');
     });
 
-    it('Should get month values according to formatLocale', () => {
+    it('Should get short month values according to locale', () => {
+        const months = getMonths(null, 'en', 'short');
+
+        expect(months).toHaveLength(12);
+        expect(months[0].text).toEqual('Jan');
+        expect(months[1].text).toEqual('Feb');
+        expect(months[2].text).toEqual('Mar');
+    });
+
+    it('Should get long month values according to formatLocale', () => {
         const months = getMonths(de, 'en', 'long');
 
         expect(months).toHaveLength(12);
         expect(months[0].text).toEqual('Januar');
+        expect(months[1].text).toEqual('Februar');
+        expect(months[2].text).toEqual('März');
     });
 
-    it('Should get month values by fallback to locale', () => {
+    it('Should get long month values by fallback to locale', () => {
         // Pass incorrect formatLocale
         const months = getMonths(null, 'de', 'long');
 
         expect(months).toHaveLength(12);
         expect(months[0].text).toEqual('Januar');
+        expect(months[1].text).toEqual('Februar');
+        expect(months[2].text).toEqual('März');
+    });
+
+    it('Should get short month values according to formatLocale', () => {
+        const months = getMonths(de, 'en', 'short');
+
+        expect(months).toHaveLength(12);
+        expect(months[0].text).toEqual('Jan');
+        expect(months[1].text).toEqual('Feb');
+        expect(months[2].text).toEqual('Mär');
+    });
+
+    it('Should get short month values by fallback to locale', () => {
+        // Pass incorrect formatLocale
+        const months = getMonths({}, 'de', 'short');
+
+        expect(months).toHaveLength(12);
+        expect(months[0].text).toEqual('Jan');
+        expect(months[1].text).toEqual('Feb');
+        expect(months[2].text).toEqual('Mär');
     });
 
     it('Should get default pattern', () => {


### PR DESCRIPTION
The same issue we have in https://github.com/Vuepic/vue-datepicker/issues/817, but with days names.
In negative timezones, we faced the shift in days. Saturday became the first day of the week.
<img width="337" alt="image" src="https://github.com/Vuepic/vue-datepicker/assets/22558332/2331331e-8397-4f92-b318-85e3597691cf">

I've added small fix. And also implement some new tests.

I also have an alternative solution without using date-fns `format` function at all. Will post it bellow, and maybe we can switch to it, because of optimization effort.