### PR TITLE
fix: Arrow not positioned correctly when the field at the most right

### DIFF
--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -251,6 +251,8 @@
         const inputRect = props.getInputRect();
         if (inputRect?.width < calendarWidth?.value && inputRect?.left <= (menuRect?.left ?? 0)) {
             return `${inputRect?.width / 2}px`;
+        } else if (inputRect?.right >= (menuRect?.right ?? 0) && inputRect?.width < calendarWidth?.value) {
+            return `${calendarWidth?.value - inputRect?.width / 2}px`;
         }
         return '50%';
     });


### PR DESCRIPTION
this is a fix for issue https://github.com/Vuepic/vue-datepicker/issues/920

## the bug:

the popup arrow is not pointing to the center of the field, when the field is on the right most of the area and there is not enough screen width to center the popup. This issue seems solved only when it is on the left via issue https://github.com/Vuepic/vue-datepicker/issues/802.

## the fix:

I added check for the right side. if there is not enough width, then position arrow to middle of input.

## tests

done, no issue locally. but pull request showing one failed test.  
npm run test:coverage and npm run test works fine locally

## proof
![Screenshot 2024-06-25 09 55 36 msedge GGO](https://github.com/Vuepic/vue-datepicker/assets/26244062/87c63096-5aae-4af0-add4-c97b0a93ed5e)

and it works for other situations, left and default
![Screenshot 2024-06-25 09 55 56 msedge 8a1](https://github.com/Vuepic/vue-datepicker/assets/26244062/808f2c87-5ecc-42b6-a019-9d69d0429876)
![Screenshot 2024-06-25 09 53 59 msedge cF9](https://github.com/Vuepic/vue-datepicker/assets/26244062/4bbbf109-1d74-4e05-a9b4-25c9cb3f64a3)


