### PR TITLE
fix: Wrong month & year assignment for auto-range multi calendars

### DIFF
--- a/src/VueDatePicker/components/DatePicker/date-picker.ts
+++ b/src/VueDatePicker/components/DatePicker/date-picker.ts
@@ -468,7 +468,7 @@ export const useDatePicker = (
         if (defaultedMultiCalendars.value.count > 0) {
             for (let i = 1; i < defaultedMultiCalendars.value.count; i++) {
                 const next = getNextMonthYear(
-                    set(getDate(date), { year: month.value(i - 1), month: year.value(i - 1) }),
+                    set(getDate(date), { year: year.value(i - 1), month: month.value(i - 1) }),
                 );
                 setCalendarMonthYear(i, next.month, next.year);
             }


### PR DESCRIPTION
This PR solves #909, in which the second calendar appears with the wrong year and month when simultaneously using auto-range and multi-calendar features.

Upon investigation, I found that the year and month values were mistakenly assigned interchangeably in the `handleNextCalendarAutoRange` function, leading to the bug.

After fixing it, I confirmed that the second calendar showed the correct year and month. 