### PR TITLE
fix: Wrong class for the clear button slot

### DIFF
--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -59,7 +59,7 @@
             </div>
             <span
                 v-if="$slots['clear-icon'] && inputValue && clearable && !disabled && !readonly"
-                class="dp__clear_icon"
+                class="dp--clear-btn"
                 ><slot name="clear-icon" :clear="onClear"
             /></span>
             <button


### PR DESCRIPTION
## Describe your changes

Because the old class, `dp__clear_icon`, was still applied to the parent element of the clear button slot, the clear button was misplaced in the field.

This PR fixes the class so the button is positioned correctly.

Here are the results:

### Before fix

![image](https://github.com/user-attachments/assets/1e7bae3a-2f63-49f3-a07f-7bd2d20f7887)


### After fix

![image](https://github.com/user-attachments/assets/bcc85a95-3ea9-4140-b428-2c6a7f10b4aa)

<details>
<summary>The code</summary>

```vue
<template>
    <div class="wrapper">
        <Datepicker v-model="selectedDate" placeholder="Select Date" clearable>
            <template #clear-icon="{ clear }">
                <div class="clear" @click="clear">⭐</div>
            </template>
        </Datepicker>
    </div>
</template>

<script lang="ts" setup>
    import { ref } from 'vue';
    import Datepicker from '../src/VueDatePicker/VueDatePicker.vue';

    const selectedDate = ref();
</script>

<style lang="scss">
    @import 'src/VueDatePicker/style/main';
    .wrapper {
        padding: 200px;
    }

    .clear {
        margin: 4px 8px;
    }
</style>
```

</details>

## Issue ticket number and link
https://github.com/Vuepic/vue-datepicker/issues/945

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test