### PR TITLE
fix: bugs with tab-handling in `text-input` mode

### DIFF
--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -245,10 +245,10 @@
         if (clearBtnRef.value && fromInput && !clearBtnFocused.value) {
             ev.preventDefault();
             clearBtnFocused.value = true;
-            return clearBtnRef.value?.focus();
+            clearBtnRef.value?.focus();
         }
         if (defaultedTextInput.value.enabled && defaultedTextInput.value.tabSubmit) {
-            parseInput((ev.target as HTMLInputElement).value);
+            parseInput((inputRef.value as HTMLInputElement).value);
         }
 
         if (defaultedTextInput.value.tabSubmit && isValidDate(parsedDate.value) && props.inputValue !== '') {


### PR DESCRIPTION
## Describe your changes
Fixes 2 bugs that occurs when pressing TAB while using `text-input` mode:

#### **Bug: If you write a date and press tab, the focus will go to the clear-button. When tabbing away from the button (either back to input, or further down the page), the value will reset because it fetches the value from the wrong element.**

Fix: The value is now fetched directly from the `inputRef` in `handleTab`. This is because the previous code would get the value from `ev.target` which will be the clear-button (`<button>`) when TAB'ing.

#### **Bug: When pressing TAB, the focus switches to the clear-button. However, the string is not automatically parsed.**

I would expect the string to be parsed as soon as i pressed TAB, even though the focus shifts to the clear-button. I have therefore updated the `handleTab` to do that.

## Issue ticket number and link

Fixes #961 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test