### PR TITLE
fix: root-click not needed with input slot (fixes #973)

### DIFF
--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -1,5 +1,5 @@
 <template>
-    <div @click="handleOpen">
+    <div @click="(e) => !$slots['dp-input'] && handleOpen(e)">
         <slot v-if="$slots.trigger && !$slots['dp-input'] && !defaultedInline.enabled" name="trigger" />
         <div v-if="!$slots.trigger && (!defaultedInline.enabled || defaultedInline.input)" class="dp__input_wrap">
             <slot


### PR DESCRIPTION
## Describe your changes
Disables root level click event if a custom input is provided in dp-input.  There's really no need for it if the input is being customized and it blocks some click events at that input level.

## Issue ticket number and link
#973

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test