### PR TITLE
Month range picker doesn't trigger rangeStart rangeEnd events properly

### DIFF
--- a/src/VueDatePicker/composables/shared.ts
+++ b/src/VueDatePicker/composables/shared.ts
@@ -30,16 +30,12 @@ export const setMonthOrYearRange = (
     if (rangeDate.length === 2 && rangeDate[1] !== null) {
         rangeDate = [];
     }
-
     if (!rangeDate.length) {
         rangeDate = [date];
         emit('range-start', date);
-    } else if (isDateBefore(date, rangeDate[0])) {
-        rangeDate.unshift(date);
-        emit('range-start', rangeDate[0]);
-        emit('range-start', rangeDate[1]);
     } else {
-        rangeDate[1] = date;
+        if (isDateBefore(date, rangeDate[0])) rangeDate.unshift(date);
+        else rangeDate[1] = date;
         emit('range-end', date);
     }
 


### PR DESCRIPTION
## Describe your changes
I changed how events are triggered, because when end of range date selected is sooner than start of range date, it triggers range-start twice.

So now, i mantain the unshift in the array to have dates in proper order, but triggering range-end event since range selection is finished.

## Issue ticket number and link

Fixes #1005 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test