### PR TITLE
fix: "Now" action row button works with multi-days

### DIFF
--- a/src/VueDatePicker/components/DatePicker/date-picker.ts
+++ b/src/VueDatePicker/components/DatePicker/date-picker.ts
@@ -608,14 +608,17 @@ export const useDatePicker = (
     // Select current date on now button
     const selectCurrentDate = (): void => {
         const dateInTz = dateToTimezoneSafe(getDate(), defaultedTz.value);
-        if (!defaultedRange.value.enabled) {
-            modelValue.value = dateInTz;
-        } else if (modelValue.value && Array.isArray(modelValue.value) && modelValue.value[0]) {
-            modelValue.value = isDateBefore(dateInTz, modelValue.value[0])
-                ? [dateInTz, modelValue.value[0]]
-                : [modelValue.value[0], dateInTz];
+        if (modelValue.value && Array.isArray(modelValue.value)) {
+            if (defaultedRange.value.enabled) {
+                const dateInTz = dateToTimezoneSafe(getDate(), defaultedTz.value);
+                modelValue.value = isDateBefore(dateInTz, modelValue.value[0])
+                    ? [dateInTz, modelValue.value[0]]
+                    : [modelValue.value[0], dateInTz];
+            } else {
+                modelValue.value = [...modelValue, dateInTz];
+            }
         } else {
-            modelValue.value = [dateInTz];
+            modelValue.value = dateInTz;
         }
 
         selectOnAutoApply();


### PR DESCRIPTION
## Describe your changes

The changes fix a problem with the 'now' button combined with multiple dates. More details can be found in an issue. I haven't changed the behavior for the month-picker, time-picker, and other similar components, where the 'now' button also doesn't work

## Issue ticket number and link

https://github.com/Vuepic/vue-datepicker/issues/1000

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test