### PR TITLE
feat: alwaysClearable prop

### DIFF
--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -58,11 +58,11 @@
                     @click="emit('toggle')"
                 />
             </div>
-            <span v-if="$slots['clear-icon'] && inputValue && clearable && !disabled && !readonly" class="dp--clear-btn"
+            <span v-if="$slots['clear-icon'] && (alwaysClearable || inputValue && clearable && !disabled && !readonly)" class="dp--clear-btn"
                 ><slot name="clear-icon" :clear="onClear"
             /></span>
             <button
-                v-if="clearable && !$slots['clear-icon'] && inputValue && !disabled && !readonly"
+                v-if="!$slots['clear-icon'] && (alwaysClearable || clearable && inputValue && !disabled && !readonly)"
                 :aria-label="defaultedAriaLabels?.clearInput"
                 class="dp--clear-btn"
                 type="button"

--- a/src/VueDatePicker/props.ts
+++ b/src/VueDatePicker/props.ts
@@ -120,6 +120,7 @@ export const AllProps = {
     placeholder: { type: String as PropType<string>, default: '' },
     hideInputIcon: { type: Boolean as PropType<boolean>, default: false },
     clearable: { type: Boolean as PropType<boolean>, default: true },
+    alwaysClearable: { type: Boolean as PropType<boolean>, default: false },
     state: { type: Boolean as PropType<boolean | null>, default: null },
     required: { type: Boolean as PropType<boolean>, default: false },
     autocomplete: { type: String as PropType<string>, default: 'off' },


### PR DESCRIPTION
## Describe your changes
I have added a prop which makes the `clear-icon` slot present regardless of the state of the DatepickerInput
It might help developers who have created their own logic for the clear button

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [X] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test -> There isn't any test for clearable prop