### PR TITLE
feat: Allow presetDates values to be functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "date-fns": "^4.1.0"
   },
   "peerDependencies": {
-    "vue": ">=3.2.0"
+    "vue": ">=3.3.0"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -120,7 +120,7 @@
 </template>
 
 <script lang="ts" setup>
-    import { computed, onMounted, onUnmounted, ref, useSlots } from 'vue';
+    import { computed, onMounted, onUnmounted, ref, toValue, useSlots } from 'vue';
 
     import ActionRow from '@/components/ActionRow.vue';
 
@@ -135,7 +135,7 @@
     import QuarterPicker from '@/components/QuarterPicker/QuarterPicker.vue';
 
     import type { DynamicClass, MenuView, InternalModuleValue, MenuExposedFn, MonthModel } from '@/interfaces';
-    import type { PropType } from 'vue';
+    import type { MaybeRefOrGetter, PropType } from 'vue';
     import { ArrowDirection, EventKey } from '@/constants';
     import { useResponsive } from '@/composables/responsive';
 
@@ -368,8 +368,8 @@
         callChildFn('selectCurrentDate');
     };
 
-    const presetDate = (value: Date[] | string[] | string | Date, noTz?: boolean) => {
-        callChildFn('presetDate', value, noTz);
+    const presetDate = (value: MaybeRefOrGetter<Date[] | string[] | string | Date>, noTz?: boolean) => {
+        callChildFn('presetDate', toValue(value), noTz);
     };
 
     const clearHoverDate = () => {

--- a/src/VueDatePicker/interfaces.ts
+++ b/src/VueDatePicker/interfaces.ts
@@ -1,4 +1,4 @@
-import type { ComponentPublicInstance, Ref } from 'vue';
+import type { ComponentPublicInstance, Ref, MaybeRefOrGetter } from 'vue';
 import type { HeaderPicker } from '@/constants';
 import DatepickerMenu from '@/components/DatepickerMenu.vue';
 import type DatepickerInput from '@/components/DatepickerInput.vue';
@@ -122,7 +122,7 @@ export type DisabledDatesProp = Date[] | string[] | IDisableDates;
 
 export type PresetDate = {
     label: string;
-    value: Date[] | string[] | Date | string;
+    value: MaybeRefOrGetter<Date[] | string[] | Date | string>;
     style?: Record<string, string>;
     slot?: string;
     noTz?: boolean;


### PR DESCRIPTION
## Describe your changes
Update DatepickerMenu to allow the function presetDate to recibe a `MaybeRefOrGetter<Date[] | string[] | string | Date>` from `PresetDate`.

Update the `PresetDate` interface present in interfaces.ts, to use type MaybeRefOrGetter from vue

Update `package.json`, set peerDependencies to the minimun required vue 3.3.0 (required by MaybeRefOrGetter)

Add 2 new tests, fixed 1:
- `Should preset range from preset-dates` now click on the preset instead of calling its internal function `presetDate`
- add new test `Should preset range from preset-dates when range its a function`, check when value is a function, it should behave same as before
- add new test `Should correctly set today when preset-dates its a function and selected 2 days later`, check that presetDate is executed when pressed, in this case 2 days latter, and returns the correct date, and not the date of when it was mounted.

## Issue ticket number and link
Solves #1031 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test
- [ ] update documentation

Dont know how to update the documentation, interface should be updated to the new MaybeRefOrGetter value, and maybe encorage to use functions instead of hard coded values.