### PR TITLE
feat: expose isDisabled method to month-year slot

### DIFF
--- a/src/VueDatePicker/components/DatePicker/DpHeader.vue
+++ b/src/VueDatePicker/components/DatePicker/DpHeader.vue
@@ -4,7 +4,16 @@
             <div class="dp__month_year_wrap">
                 <slot
                     name="month-year"
-                    v-bind="{ month, year, months, years, updateMonthYear, handleMonthYearChange, instance }"
+                    v-bind="{
+                        month,
+                        year,
+                        months,
+                        years,
+                        updateMonthYear,
+                        handleMonthYearChange,
+                        instance,
+                        isDisabled,
+                    }"
                 />
             </div>
         </template>


### PR DESCRIPTION
## Describe your changes
Exposed `isDisabled` method to `#month-year` slot so prev/next button could be custom styled based on the disabled state

## Issue ticket number and link
https://github.com/Vuepic/vue-datepicker/issues/1056

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test