### PR TITLE
fix: allow dates after 1970 in range mode

### DIFF
--- a/src/VueDatePicker/components/DatepickerInput.vue
+++ b/src/VueDatePicker/components/DatepickerInput.vue
@@ -182,7 +182,7 @@
 
         if (dateOne) {
             const parsedDateOne = parser(dateOne.trim());
-            const parsedDateTwo = dateTwo ? parser(dateTwo.trim()) : null;
+            const parsedDateTwo = dateTwo ? parser(dateTwo.trim()) : undefined;
             if (isAfter(parsedDateOne as Date, parsedDateTwo as Date)) return;
 
             const parsedArr = parsedDateOne && parsedDateTwo ? [parsedDateOne, parsedDateTwo] : [parsedDateOne];


### PR DESCRIPTION
## Describe your changes
Date-fns v4.1.0 treats `null` as `01/01/1970` [(reference)](https://github.com/date-fns/date-fns/issues/3946), which changes the behavior compared to previous versions. To maintain the same behavior as before, we can pass `undefined` instead of `null`. In this change, `null` is replaced with `undefined` while initializing `parsedDateTwo`.

## Issue ticket number and link
Fixes #1082

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test