### PR TITLE
fix: handle arabic short week days

### DIFF
--- a/src/VueDatePicker/utils/util.ts
+++ b/src/VueDatePicker/utils/util.ts
@@ -26,11 +26,15 @@ export const getArrayInArray = <T>(list: T[], increment = 3): T[][] => {
 
 function dayNameIntlMapper(locale: string) {
     return (day: number) => {
-        return new Intl.DateTimeFormat(locale, { weekday: 'short', timeZone: 'UTC' })
-            .format(new Date(`2017-01-0${day}T00:00:00+00:00`))
-            .slice(0, 2);
-    };
-}
+        const formattedDate = new Intl.DateTimeFormat(locale, {
+            weekday: 'short',
+            timeZone: 'UTC'
+        }).format(new Date(`2017-01-0${day}T00:00:00+00:00`));
+
+        // Arabic locale requires different slice indexes to get correct abbreviation
+        return locale === 'ar' ? formattedDate.slice(2, 5) : formattedDate.slice(0, 2);
+    }
+};
 
 function dayNameDateFnsMapper(formatLocale: Locale) {
     return (day: number) => {

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -109,6 +109,14 @@ describe('Utils and date utils formatting', () => {
         expect(days[1]).toEqual('Di');
     });
 
+    it('Should get specific day names on arabic', () => {
+        // Pass arabic locale
+        const days = getDayNames(null, 'ar', 1);
+
+        expect(days).toHaveLength(7);
+        expect(days[1]).toEqual('ثلا');
+    });
+
     it('Should get day names according to formatLocale', () => {
         const days = getDayNames(de, 'en', 1);
 


### PR DESCRIPTION
## Describe your changes
When using `ar` as locale, week days' short names were identical because we would always `slice` the full day names on indexes 0 to 2 to format them. 

I made an exception for arabic, slicing the weekdays on indexes 2 to 5

This is how it looks like now:
| Before | After |
| ------- | --------|
|  <img width="268" alt="image" src="https://github.com/user-attachments/assets/f38e9bdb-e3f9-4b25-9654-7e51a43bb6d4" /> | <img width="264" alt="image" src="https://github.com/user-attachments/assets/06ae99e2-4463-4887-bed1-ba032427598c" />|


## Issue ticket number and link
Fixes #1087 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test