### PR TITLE
fix: App Context missing in slots

### DIFF
--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -83,6 +83,7 @@
         watch,
         Teleport as TeleportCmp,
         nextTick,
+        getCurrentInstance,
     } from 'vue';
 
     import DatepickerInput from '@/components/DatepickerInput.vue';
@@ -177,6 +178,8 @@
     } = useDefaults(props);
     const { menuTransition, showTransition } = useTransitions(defaultedTransitions);
     const { isMobile } = useResponsive(defaultedConfig);
+
+    const currentInstance = getCurrentInstance();
 
     onMounted(() => {
         parseExternalModelValue(props.modelValue);
@@ -320,7 +323,7 @@
 
     const openMenu = () => {
         if (!props.disabled && !props.readonly) {
-            shadowRender(DatepickerMenu, props);
+            shadowRender(currentInstance, DatepickerMenu, props);
             setMenuPosition(false);
             isOpen.value = true;
 

--- a/src/VueDatePicker/composables/position.ts
+++ b/src/VueDatePicker/composables/position.ts
@@ -1,4 +1,4 @@
-import type { Component, ComputedRef, Ref, Slots } from 'vue';
+import type { Component, ComponentInternalInstance, ComputedRef, Ref, Slots } from 'vue';
 import { h, ref, render, toRef, watch } from 'vue';
 import {
     type DatepickerInputRef,
@@ -255,7 +255,7 @@ export const usePosition = ({
     };
 
     // Renders invisible menu on open to determine the menu dimensions
-    const shadowRender = (DPMenu: Component, props: AllPropsType) => {
+    const shadowRender = (instance: ComponentInternalInstance | null, DPMenu: Component, props: AllPropsType) => {
         const container = document.createElement('div');
         const input = unrefElement(inputRef as MaybeElementRef)?.getBoundingClientRect();
         container.setAttribute('id', 'dp--temp-container');
@@ -278,6 +278,9 @@ export const usePosition = ({
             },
             Object.fromEntries(mappedSlots.map((slot) => [slot, slots[slot]])),
         );
+        if (instance != null) {
+            el.appContext = instance.appContext;
+        }
 
         render(el, container);
         menuRect.value = el.el?.getBoundingClientRect();


### PR DESCRIPTION
## Describe your changes
When using slots like this example:
```vue
<script setup>
import { Select } from 'primevue'
import VueDatePicker from '@vuepic/vue-datepicker'
import '@vuepic/vue-datepicker/dist/main.css'

const date = ref()
</script>

<template>
    <VueDatePicker v-model="date">
        <template #left-sidebar>
            <Select />
        </template>
    </VueDatePicker>
</template>
```
The `<Select>` component would not get passed the appContext while shadow rendering which causes errors, especially on libraries like PrimeVue which require the appContext to use config properties.

Setting appContext after calling h() is what is described by Evan You: https://github.com/vuejs/core/issues/2097#issuecomment-707975628

## Issue ticket number and link
https://github.com/Vuepic/vue-datepicker/issues/1092

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test