### PR TITLE
fix: resolve memory leaks by detached elements and event listeners

### DIFF
--- a/src/VueDatePicker/components/DatePicker/DpCalendar.vue
+++ b/src/VueDatePicker/components/DatePicker/DpCalendar.vue
@@ -114,7 +114,7 @@
 </template>
 
 <script lang="ts" setup>
-    import { computed, nextTick, onMounted, ref } from 'vue';
+    import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
     import { getISOWeek, getWeek } from 'date-fns';
 
     import {
@@ -213,6 +213,19 @@
         }
         if (props.monthChangeOnScroll && calendarWrapRef.value) {
             calendarWrapRef.value.addEventListener('wheel', onScroll, { passive: false });
+        }
+    });
+
+    onUnmounted(() => {
+        if (!defaultedConfig.value.noSwipe) {
+            if (calendarWrapRef.value) {
+                calendarWrapRef.value.removeEventListener('touchstart', onTouchStart);
+                calendarWrapRef.value.removeEventListener('touchend', onTouchEnd);
+                calendarWrapRef.value.removeEventListener('touchmove', onTouchMove);
+            }
+        }
+        if (props.monthChangeOnScroll && calendarWrapRef.value) {
+            calendarWrapRef.value.removeEventListener('wheel', onScroll);
         }
     });
 

--- a/src/VueDatePicker/components/DatepickerMenu.vue
+++ b/src/VueDatePicker/components/DatepickerMenu.vue
@@ -217,13 +217,6 @@
                 focusMenu();
             }
             if (menu) {
-                const stopDefault = (event: Event) => {
-                    isMenuActive.value = true;
-                    if (defaultedConfig.value.allowPreventDefault) {
-                        event.preventDefault();
-                    }
-                    checkStopPropagation(event, defaultedConfig.value, true);
-                };
                 menu.addEventListener('pointerdown', stopDefault);
                 menu.addEventListener('mousedown', stopDefault);
             }
@@ -233,7 +226,14 @@
 
     onUnmounted(() => {
         window.removeEventListener('resize', getCalendarWidth);
-        document.addEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('mousedown', handleClickOutside);
+
+        const menu = unrefElement(dpMenuRef);
+    
+        if (menu) {
+            menu.removeEventListener('pointerdown', stopDefault);
+            menu.removeEventListener('mousedown', stopDefault);
+        }
     });
 
     const getCalendarWidth = (): void => {
@@ -306,6 +306,14 @@
         }),
     );
 
+    const stopDefault = (event: Event) => {
+        isMenuActive.value = true;
+        if (defaultedConfig.value.allowPreventDefault) {
+            event.preventDefault();
+        }
+        checkStopPropagation(event, defaultedConfig.value, true);
+    };
+    
     const handleDpMenuClick = (ev: Event) => {
         checkStopPropagation(ev, defaultedConfig.value, true);
     };


### PR DESCRIPTION
## Describe your changes
Resolve memory leaks by removing event listeners on component unmount 
 - Remove `touch` and `wheel` event listeners in `DpCalendar` component
 - Remove `mousedown` and `pointerdown` event listeners in `DatepickerMenu` component

## Comparision of heap snapshots with this fix (left) and without this fix (right)

### With passing  :transitions="false"
<img width="1424" alt="Screenshot 2025-03-16 at 12 54 32" src="https://github.com/user-attachments/assets/23838c21-2a8d-420e-8a33-b41dfa488d51" />
This fix reduces retained size to 0%.

### Without passing  :transitions="false"
<img width="1424" alt="Screenshot 2025-03-16 at 13 12 13" src="https://github.com/user-attachments/assets/77d63291-2d84-4e5a-88cc-eed8d455c94d" />
Even with the fix, there is still increase in retained size (as some elements are retained by transition). However, it still has less memory consumption compared to the situation without the fix.

### Comparision of detached elements profile with this fix (left) and without this fix (right)
<img width="1411" alt="Screenshot 2025-03-16 at 13 14 33" src="https://github.com/user-attachments/assets/af0f14fd-e18c-4c29-a74b-a168fffb69a8" />


## Issue ticket number and link
Fixes #1083

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test