### PR TITLE
fix: vite warning in console

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/vue-datepicker.js",
-      "require": "./dist/vue-datepicker.umd.cjs",
-      "types": "./index.d.ts"
+      "require": "./dist/vue-datepicker.umd.cjs"
     },
     "./dist/main.css": {
       "import": "./dist/main.css",

--- a/src/VueDatePicker/components/Common/ArrowBtn.vue
+++ b/src/VueDatePicker/components/Common/ArrowBtn.vue
@@ -7,8 +7,8 @@
         tabindex="0"
         :aria-label="ariaLabel"
         :aria-disabled="disabled || undefined"
-        @click="$emit('activate')"
-        @keydown="checkKeyDown($event, () => $emit('activate'), true)"
+        @click="emit('activate')"
+        @keydown="checkKeyDown($event, () => emit('activate'), true)"
     >
         <span class="dp__inner_nav" :class="{ dp__inner_nav_disabled: disabled }">
             <slot />
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts" setup>
-    import { onMounted, ref } from 'vue';
+    import { onMounted, ref, type Ref } from 'vue';
     import { checkKeyDown } from '@/utils/util';
 
     defineOptions({
@@ -26,7 +26,10 @@
         },
     });
 
-    const emit = defineEmits(['activate', 'set-ref']);
+    const emit = defineEmits<{
+        'activate': []
+        'set-ref': [i: Ref<HTMLElement | null>]
+    }>();
 
     defineProps<{
         ariaLabel?: string;
@@ -36,5 +39,5 @@
 
     const elRef = ref<HTMLElement | null>(null);
 
-    onMounted(() => emit('set-ref', elRef.value));
+    onMounted(() => emit('set-ref', elRef)); // eslint-disable-line vue/no-ref-as-operand
 </script>

--- a/src/VueDatePicker/components/Common/ArrowBtn.vue
+++ b/src/VueDatePicker/components/Common/ArrowBtn.vue
@@ -36,5 +36,5 @@
 
     const elRef = ref<HTMLElement | null>(null);
 
-    onMounted(() => emit('set-ref', elRef));
+    onMounted(() => emit('set-ref', elRef.value));
 </script>


### PR DESCRIPTION
While working on #1109 I noticed that when running the dev script, it displays the following warning in console:

**_The condition "types" here will never be used as it comes after both "import" and "require" [package.json]_**

## Describe your changes
- Update package.json, move `exports.".".types` to the top of the list
- Run lint script, changes `ArrowBtn.vue` adds missing `.value` to ref `elRef`

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors