### PR TITLE
fix: `auto-apply` not working with `text-input`

### DIFF
--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -239,7 +239,7 @@
         emitModelValue,
         formatInputValue,
         checkBeforeEmit,
-    } = useExternalInternalMapper(emit, props, isInputFocused);
+    } = useExternalInternalMapper(emit, props, { isInputFocused, isTextInputDate });
 
     const wrapperClass = computed(
         (): DynamicClass => ({
@@ -469,7 +469,7 @@
                 selectDate();
                 emit('text-submit');
             } else if (props.autoApply) {
-                autoApplyValue();
+                autoApplyValue(true);
             }
             nextTick().then(() => {
                 isTextInputDate.value = false;

--- a/src/VueDatePicker/composables/external-internal-mapper.ts
+++ b/src/VueDatePicker/composables/external-internal-mapper.ts
@@ -24,7 +24,11 @@ import { modelTypePredefined } from '@/constants';
 /**
  * Handles values from external to internal and vise versa
  */
-export const useExternalInternalMapper = (emit: VueEmit, props: AllPropsType, isInputFocused: Ref<boolean>) => {
+export const useExternalInternalMapper = (
+    emit: VueEmit,
+    props: AllPropsType,
+    { isInputFocused, isTextInputDate }: { isInputFocused: Ref<boolean>; isTextInputDate: Ref<boolean> },
+) => {
     const internalModelValue = ref();
 
     const { defaultedTextInput, defaultedRange, defaultedTz, defaultedMultiDates, getDefaultPattern } =
@@ -267,6 +271,9 @@ export const useExternalInternalMapper = (emit: VueEmit, props: AllPropsType, is
      * Also does the validation of the provided value, if invalid it will use null as a default or an empty value
      */
     const parseExternalModelValue = (value: ModelValue): void => {
+        // Prevent text input from being overridden by external value while typing
+        if (isTextInputDate.value) return;
+
         const mappedDate = mapExternalToInternal(value);
 
         if (isValidDate(convertType(mappedDate))) {


### PR DESCRIPTION
## Describe your changes
Prevent external value updates from overriding text input while typing, and prevent the menu from closing on auto-apply.

## Issue ticket number and link
Fixes #1106

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test

Note: Two unit tests are currently failing, but they are not related to my changes.