### PR TITLE
Fix missing value and text props in year slot when using the month picker

### DIFF
--- a/src/VueDatePicker/components/shared/YearModePicker.vue
+++ b/src/VueDatePicker/components/shared/YearModePicker.vue
@@ -20,7 +20,7 @@
             @click="() => toggleYearPicker(false)"
             @keydown.enter="() => toggleYearPicker(false)"
         >
-            <slot v-if="$slots.year" name="year" :year="year" />
+            <slot v-if="$slots.year" name="year" :year="year" :text="yearDisplayVal" :value="year" />
             <template v-if="!$slots.year">{{ year }}</template>
         </button>
         <ArrowBtn
@@ -69,7 +69,8 @@
     import { useCommon, useDefaults, useTransitions } from '@/composables';
     import { PickerBaseProps } from '@/props';
 
-    import { type PropType, ref } from 'vue';
+    import { type PropType, ref, computed } from 'vue';
+    import { formatNumber } from '@/utils/util';
     import type { OverlayGridItem } from '@/interfaces';
 
     const emit = defineEmits(['toggle-year-picker', 'year-select', 'handle-year']);
@@ -88,6 +89,8 @@
     const { showTransition, transitionName } = useTransitions(defaultedTransitions);
 
     const overlayOpen = ref(false);
+
+    const yearDisplayVal = computed((): string => formatNumber(props.year, props.locale));
 
     const toggleYearPicker = (flow = false, show?: boolean) => {
         overlayOpen.value = !overlayOpen.value;

--- a/src/VueDatePicker/components/shared/YearModePicker.vue
+++ b/src/VueDatePicker/components/shared/YearModePicker.vue
@@ -21,7 +21,7 @@
             @keydown.enter="() => toggleYearPicker(false)"
         >
             <slot v-if="$slots.year" name="year" :year="year" :text="yearDisplayVal" :value="year" />
-            <template v-if="!$slots.year">{{ year }}</template>
+            <template v-if="!$slots.year">{{ yearDisplayVal }}</template>
         </button>
         <ArrowBtn
             v-if="showRightIcon(defaultedMultiCalendars, instance)"


### PR DESCRIPTION
## Describe your changes

Fix the bug described in the #1154 . The details are as follows:

1. Fix missing value and text props in year slot when using the month picker
2. Fix not display localized text of year in month picker

## Issue ticket number and link

#1154

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test