### PR TITLE
fix(a11y): correct typo in aria-selected logic for range end dates

### DIFF
--- a/src/VueDatePicker/components/DatePicker/DpCalendar.vue
+++ b/src/VueDatePicker/components/DatePicker/DpCalendar.vue
@@ -38,7 +38,7 @@
                             :aria-selected="
                                 (dayVal.classData.dp__active_date ||
                                     dayVal.classData.dp__range_start ||
-                                    dayVal.classData.dp__range_start) ??
+                                    dayVal.classData.dp__range_end) ??
                                 undefined
                             "
                             :aria-disabled="dayVal.classData.dp__cell_disabled || undefined"


### PR DESCRIPTION
- Fix duplicate dp__range_start check in aria-selected attribute
- Ensure range end dates properly get aria-selected='true' for screen readers
- Related to issue #1165 accessibility improvements

## Describe your changes
Fixed a typo in `DpCalendar.vue` where `dp__range_start` appeared twice in the `aria-selected` logic instead of checking both `dp__range_start` and `dp__range_end`. 

This ensures range end dates get properly marked with `aria-selected="true"` for screen readers.

## Issue ticket number and link
Related to #1165 
**Note**: The main `aria-pressed` issue from #1165 was fixed in commit `975928bd` (not yet released). This PR adds an additional accessibility improvement for range end dates.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test