### PR TITLE
Fix #1177 Update formatting documentation from 'quarter' to 'day'

### DIFF
--- a/docs/props/formatting/index.md
+++ b/docs/props/formatting/index.md
@@ -141,7 +141,7 @@ Changes the format quarter name in the quarter picker
 ```
 :::
 
-### `quarter`
+### `day`
 
 Changes the format of the day value in the calendar
 


### PR DESCRIPTION
Changes the format property from 'quarter' to 'day' in the documentation.

## Describe your changes
Fix the docs

## Issue ticket number and link
https://github.com/Vuepic/vue-datepicker/issues/1177