### PR TITLE
fix(VueDatePicker): menu not opening when centered prop is enabled

### DIFF
--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -117,7 +117,7 @@
 
     const slots = useSlots();
     const isOpen = ref(false);
-    const shouldRender = ref(inline.value.enabled);
+    const shouldRender = ref(inline.value.enabled || rootProps.centered);
     const modelValueRef = toRef(rootProps, 'modelValue');
     const timezoneRef = toRef(rootProps, 'timezone');
 

--- a/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -60,4 +60,11 @@ describe('Test Suite 1', () => {
             expect(getMonthToggleBtn(dp).text()).toEqual(getMonthToggleText(nextMonth));
         });
     });
+
+    describe('centered option', () => {
+        it('Should open menu when centered is enabled', async () => {
+            const dp = await openMenu({ centered: true });
+            expect(dp.find('.dp__menu').exists()).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Describe your changes
The datepicker menu did not open when the `centered` prop was enabled because `shouldRender` was initialized as `false` for all non-inline modes. This prevented the menu from rendering when `isOpen` became `true`.

This PR updates the initialization so that `shouldRender` becomes `true` when either `inline.enabled` or `rootProps.centered` is active. This ensures the menu opens correctly in centered mode.

A minimal unit test was added to verify that the menu renders when `centered: true` is enabled.

## Issue ticket number and link
Fixes #1195

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have added or updated unit tests when needed
