### PR TITLE
Use Enums for WeekStart

### DIFF
--- a/src/VueDatePicker/constants/defaults.ts
+++ b/src/VueDatePicker/constants/defaults.ts
@@ -1,4 +1,4 @@
-import { WeekStart } from '@/types';
+import { WeekStart } from '.';
 import { enUS } from 'date-fns/locale';
 
 export const defaultRangeOptions = {
@@ -149,7 +149,7 @@ export const basePropDefaults = {
 };
 
 export const propDefaults = {
-    weekStart: WeekStart.Sunday,
+    weekStart: WeekStart.Monday,
     yearRange: (): [number, number] => [1900, 2100],
     ui: () => ({}),
     locale: () => enUS,

--- a/src/VueDatePicker/constants/index.ts
+++ b/src/VueDatePicker/constants/index.ts
@@ -53,3 +53,13 @@ export enum MAP_KEY_FORMAT {
     YEAR = 'yyyy',
     DATE = 'dd-MM-yyyy',
 }
+
+export enum WeekStart {
+    Sunday = 0,
+    Monday = 1,
+    Tuesday = 2,
+    Wednesday = 3,
+    Thursday = 4,
+    Friday = 5,
+    Saturday = 6,
+}

--- a/src/VueDatePicker/types/enums.ts
+++ b/src/VueDatePicker/types/enums.ts
@@ -1,9 +1,0 @@
-export enum WeekStart {
-    Sunday = 0,
-    Monday = 1,
-    Tuesday = 2,
-    Wednesday = 3,
-    Thursday = 4,
-    Friday = 5,
-    Saturday = 6,
-}

--- a/src/VueDatePicker/types/index.ts
+++ b/src/VueDatePicker/types/index.ts
@@ -4,4 +4,3 @@ export * from './configs.ts';
 export * from './generic.ts';
 export * from './picker.ts';
 export * from './emits.ts';
-export * from './enums.ts';

--- a/src/VueDatePicker/types/props.ts
+++ b/src/VueDatePicker/types/props.ts
@@ -21,7 +21,7 @@ import type {
 import type { CalendarWeek, Marker, TimeModel, PresetDate, HighlightFn, DisabledTimesFn } from '@/types/picker.ts';
 import type { PickerSection, DateValue, ModelValue, SixWeekMode } from '@/types/generic.ts';
 import { basePropDefaults, type propDefaults } from '@/constants/defaults.ts';
-import type { WeekStart } from '@/types/enums.ts';
+import type { WeekStart } from '@/constants';
 
 export interface RootProps {
     multiCalendars?: boolean | number | string | Partial<MultiCalendarsConfig>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as VueDatePicker } from './VueDatePicker/VueDatePickerRoot.vue';
 export { TZDate } from '@date-fns/tz';
 export * from './VueDatePicker/types';
+export { WeekStart } from './VueDatePicker/constants';


### PR DESCRIPTION
## Describe your changes

Added a weekday enum to pass into the Vue date picker prop instead of a non-descript int/string (0-6).

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test

<img width="1564" height="515" alt="image" src="https://github.com/user-attachments/assets/67e7994f-018c-45a3-ad1f-56a270ba3084" />
