### PR TITLE
fix: Fix teleport prop type

### DIFF
--- a/src/VueDatePicker/types/props.ts
+++ b/src/VueDatePicker/types/props.ts
@@ -51,7 +51,7 @@ export interface RootProps {
     filters?: Partial<FilterConfig>;
     arrowNavigation?: boolean;
     highlight?: HighlightFn | Partial<HighlightConfig>;
-    teleport?: string | boolean | HTMLElement;
+    teleport?: boolean | string | HTMLElement;
     centered?: boolean;
     locale?: Locale;
     weekStart?: string | number | WeekStart;


### PR DESCRIPTION
## Describe your changes
boolean must come first, otherwise Vue won't interpret props without a value (i.e. just `teleport`) as a boolean, and `:teleport="true"` has to be used.

This issue has possibly appeared in 6740279178cdc47a3cb3ecdd3f5ba836697825ef (but I'm not sure)

## Issue ticket number and link
None.
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test