### PR TITLE
fix: restore dp-input model binding for formats with MMM/MMMM tokens

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -1,6 +1,48 @@
 <template>
     <div class="wrapper">
+        <h4>Default datepicker</h4>
         <VueDatePicker v-model="selectedDate" placeholder="Select Date" />
+
+        <div class="date-picker-container">
+            <h4>Custom input with MMM format (dd-MMM-yyyy)</h4>
+            <VueDatePicker
+                v-model="date"
+                model-type="yyyy-MM-dd"
+                :formats="{ input: 'dd-MMM-yyyy' }"
+                :auto-apply="true"
+            >
+                <template #dp-input="{ value, onInput, onClear }">
+                    <input
+                        type="text"
+                        :value="value"
+                        class="date-input"
+                        @input="handleInput($event, onInput, onClear)"
+                    />
+                </template>
+            </VueDatePicker>
+            <div class="model-value">Model value: {{ date }}</div>
+        </div>
+
+        <div class="date-picker-container">
+            <h4>Custom input with short year format (dd-MM-yy)</h4>
+            <VueDatePicker
+                v-model="dateShortYear"
+                model-type="yyyy-MM-dd"
+                :formats="{ input: 'dd-MM-yy' }"
+                :auto-apply="true"
+            >
+                <template #dp-input="{ value, onInput, onClear }">
+                    <input
+                        type="text"
+                        :value="value"
+                        class="date-input"
+                        placeholder="dd-MM-yy"
+                        @input="handleInput($event, onInput, onClear)"
+                    />
+                </template>
+            </VueDatePicker>
+            <div class="model-value">Model value: {{ dateShortYear }}</div>
+        </div>
     </div>
 </template>
 
@@ -9,10 +51,47 @@
     import { VueDatePicker } from '../src';
 
     const selectedDate = ref();
+
+    const date = ref();
+
+    const dateShortYear = ref();
+
+    const handleInput = (e: Event, onInputFn: (e: Event) => void, onClearFn: (e: Event) => void) => {
+        if (e.target instanceof HTMLInputElement && e.target.value === '') {
+            onClearFn(e);
+
+            return;
+        }
+
+        onInputFn(e);
+    };
 </script>
 
 <style lang="scss">
     .wrapper {
         padding: 200px;
+    }
+
+    .date-picker-container {
+        margin-top: 2rem;
+        width: 100%;
+    }
+
+    .date-input {
+        box-sizing: border-box;
+        border: 1px solid #ccc;
+        width: 100%;
+        padding: 0.5rem;
+    }
+
+    .model-value {
+        margin-top: 0.5rem;
+        font-family: monospace;
+    }
+
+    h4 {
+        margin: 0 0 0.5rem 0;
+        font-weight: 500;
+        color: #333;
     }
 </style>

--- a/src/VueDatePicker/__tests__/useTextInputUtils.spec.ts
+++ b/src/VueDatePicker/__tests__/useTextInputUtils.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+    tryParseDate,
+    parseDateWithPattern,
+    createMaskedValue,
+    applyMaxValues,
+} from '../components/DatePickerInput/useTextInputUtils';
+
+describe('useTextInputUtils', () => {
+    const referenceDate = new Date(2025, 0, 1);
+
+    describe('tryParseDate', () => {
+        it.each([
+            ['full pattern (dd-MM-yyyy)', '18-12-2025', 'dd-MM-yyyy'],
+            ['MMM format (dd-MMM-yyyy)', '18-Dec-2025', 'dd-MMM-yyyy'],
+            ['short year (dd-MM-yy)', '18-12-25', 'dd-MM-yy'],
+        ])('should parse date with %s', (_, value, pattern) => {
+            const result = tryParseDate(value, pattern, referenceDate);
+
+            expect(result).toBeInstanceOf(Date);
+            expect(result?.getDate()).toBe(18);
+            expect(result?.getMonth()).toBe(11);
+            expect(result?.getFullYear()).toBe(2025);
+        });
+
+        it.each([
+            ['invalid date string', 'invalid'],
+            ['empty string', ''],
+            ['partial input', '18-12'],
+        ])('should return null for %s', (_, value) => {
+            const result = tryParseDate(value, 'dd-MM-yyyy', referenceDate);
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('parseDateWithPattern', () => {
+        it.each([
+            ['full pattern', '18-12-2025', 'dd-MM-yyyy'],
+            ['MMM format', '18-Dec-2025', 'dd-MMM-yyyy'],
+            ['short year', '18-12-25', 'dd-MM-yy'],
+        ])('should parse date with %s', (_, value, pattern) => {
+            const result = parseDateWithPattern(value, pattern, referenceDate);
+
+            expect(result).toBeInstanceOf(Date);
+            expect(result?.getFullYear()).toBe(2025);
+        });
+
+        it('should fallback to sliced pattern for partial input', () => {
+            const result = parseDateWithPattern('18-12', 'dd-MM-yyyy', referenceDate);
+
+            expect(result).toBeInstanceOf(Date);
+            expect(result?.getDate()).toBe(18);
+            expect(result?.getMonth()).toBe(11);
+        });
+
+        it('should return null for invalid partial input', () => {
+            const result = parseDateWithPattern('abc', 'dd-MM-yyyy', referenceDate);
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('createMaskedValue', () => {
+        it.each([
+            ['date format', '18122025', 'DD/MM/YYYY', '18/12/2025'],
+            ['time format', '143022', 'hh:mm:ss', '14:30:22'],
+            ['datetime format', '181220251430', 'DD/MM/YYYY hh:mm', '18/12/2025 14:30'],
+            ['partial input (trailing delimiter)', '1812', 'DD/MM/YYYY', '18/12/'],
+            ['empty input', '', 'DD/MM/YYYY', ''],
+            ['single digit', '1', 'DD/MM/YYYY', '1'],
+        ])('should handle %s', (_, raw, format, expected) => {
+            expect(createMaskedValue(raw, format)).toBe(expected);
+        });
+    });
+
+    describe('applyMaxValues', () => {
+        it.each([
+            ['MM', '99', '12'],
+            ['DD', '45', '31'],
+            ['hh', '25', '23'],
+            ['mm', '99', '59'],
+            ['ss', '75', '59'],
+        ])('should clamp %s to max value', (token, input, expected) => {
+            expect(applyMaxValues(input, [token])).toBe(expected);
+        });
+
+        it.each([
+            ['valid values', '1512', ['DD', 'MM'], '1512'],
+            ['YYYY without clamping', '2025', ['YYYY'], '2025'],
+            ['padded values', '05', ['MM'], '05'],
+            ['partial input', '1', ['MM'], '1'],
+            ['multiple tokens', '9999', ['DD', 'MM'], '3112'],
+        ])('should handle %s', (_, input, tokens, expected) => {
+            expect(applyMaxValues(input, tokens)).toBe(expected);
+        });
+    });
+});

--- a/src/VueDatePicker/components/DatePickerInput/useInput.ts
+++ b/src/VueDatePicker/components/DatePickerInput/useInput.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue';
-import { isDate, isValid, parse, set } from 'date-fns';
+import { set } from 'date-fns';
 import { useContext, useHelperFns } from '@/composables';
+import { parseDateWithPattern, createMaskedValue, applyMaxValues } from './useTextInputUtils';
 
 export const useInput = () => {
     const {
@@ -18,36 +19,12 @@ export const useInput = () => {
             : (startTime.value ?? getTimeObjFromCurrent(getDate(), {}, timeConfig.value.enableSeconds)),
     );
 
-    const getPatternForValue = (fullPattern: string, value: string) => {
-        const separatorRegex = /[^a-zA-Z]+/g;
-        const valueSeparatorRegex = /\D+/g;
+    const parseWithPattern = (value: string, pattern: string, inputVal?: string): Date | null => {
+        const parsedDate = parseDateWithPattern(value, pattern, getDate(), rootProps.locale);
 
-        const valueParts = value.split(valueSeparatorRegex);
-        const patternParts = fullPattern.split(separatorRegex);
-        const patternSeparators = fullPattern.match(separatorRegex) || [];
-        const valueSeparators = value.match(valueSeparatorRegex) || [];
-
-        let result = '';
-
-        for (let i = 0; i < valueParts.length && i < patternParts.length; i++) {
-            if (i > 0 && valueSeparators[i - 1]) {
-                result += patternSeparators[i - 1] || valueSeparators[i - 1];
-            }
-
-            const valuePartLength = valueParts[i]?.length;
-            result += patternParts[i]?.slice(0, valuePartLength);
-        }
-
-        return result;
-    };
-
-    const parseStringToDate = (value: string, pattern: string, inputVal?: string): Date | null => {
-        const parsedDate = parse(value, getPatternForValue(pattern, value), getDate(), {
-            locale: rootProps.locale,
-        });
-
-        if (isValid(parsedDate) && isDate(parsedDate)) {
+        if (parsedDate) {
             if (inputVal || textPasted.value) return parsedDate;
+
             return set(parsedDate, {
                 hours: +assignTimeTextInput.value!.hours,
                 minutes: +assignTimeTextInput.value!.minutes,
@@ -55,80 +32,27 @@ export const useInput = () => {
                 milliseconds: 0,
             });
         }
+
         return null;
     };
 
     const parseFreeInput = (value: string, inputVal?: string): Date | null => {
-        if (typeof textInput.value.pattern === 'string') {
-            return parseStringToDate(value, textInput.value.pattern, inputVal);
+        const pattern = textInput.value.pattern;
+
+        if (typeof pattern === 'function') {
+            return pattern(value as never) as unknown as Date;
         }
 
-        if (Array.isArray(textInput.value.pattern)) {
-            let parsedDate = null;
-            for (const textVal of textInput.value.pattern) {
-                parsedDate = parseStringToDate(value, textVal, inputVal);
-                if (parsedDate) {
-                    break;
-                }
+        const patterns = typeof pattern === 'string' ? [pattern] : pattern;
+
+        if (Array.isArray(patterns)) {
+            for (const p of patterns) {
+                const parsed = parseWithPattern(value, p, inputVal);
+                if (parsed) return parsed;
             }
-            return parsedDate;
-        }
-
-        if (typeof textInput.value.pattern === 'function') {
-            return textInput.value.pattern(value as never) as unknown as Date;
         }
 
         return null;
-    };
-
-    const createMaskedValue = (raw: string, maskFormat: string) => {
-        const tokenPattern = /(YYYY|MM|DD|hh|mm|ss)/g;
-        const tokens: string[] = [...maskFormat.matchAll(tokenPattern)].map((m) => m[0]);
-        const delimiters: string[] = maskFormat.replace(tokenPattern, '|').split('|').filter(Boolean);
-        const tokenLengths: number[] = tokens.map((t) => t.length);
-
-        let masked = '',
-            index = 0;
-        for (let i = 0; i < tokens.length; i++) {
-            const len = tokenLengths[i]!;
-            const part = raw.slice(index, index + len);
-            if (!part) break;
-            masked += part;
-            if (part.length === len && delimiters[i]) masked += delimiters[i];
-            index += len;
-        }
-        return masked;
-    };
-
-    const applyMaxValues = (raw: string, tokens: string[]) => {
-        const maxValues: Record<string, number> = {
-            MM: 12,
-            DD: 31,
-            hh: 23,
-            mm: 59,
-            ss: 59,
-        };
-
-        let result = '',
-            index = 0;
-        for (let i = 0; i < tokens.length; i++) {
-            const token = tokens[i]!;
-            const len = token.length;
-            const part = raw.slice(index, index + len);
-            if (!part) break;
-
-            if (part.length < len) {
-                result += part;
-            } else {
-                let num = Number.parseInt(part, 10);
-                if (maxValues[token] && num > maxValues[token]) num = maxValues[token];
-                result += num.toString().padStart(len, '0').slice(0, len);
-            }
-
-            index += len;
-        }
-
-        return result;
     };
 
     return {

--- a/src/VueDatePicker/components/DatePickerInput/useTextInputUtils.ts
+++ b/src/VueDatePicker/components/DatePickerInput/useTextInputUtils.ts
@@ -1,0 +1,92 @@
+import { isDate, isValid, parse } from 'date-fns';
+import type { Locale } from 'date-fns';
+
+/**
+ * Try to parse a date string with the given pattern.
+ * Returns the parsed Date if valid, null otherwise.
+ */
+export const tryParseDate = (value: string, pattern: string, referenceDate: Date, locale?: Locale): Date | null => {
+    const parsed = parse(value, pattern, referenceDate, { locale });
+
+    return isValid(parsed) && isDate(parsed) ? parsed : null;
+};
+
+/**
+ * Parse a date string, trying the full pattern first,
+ * then falling back to a sliced pattern for partial input.
+ */
+export const parseDateWithPattern = (
+    value: string,
+    pattern: string,
+    referenceDate: Date,
+    locale?: Locale,
+): Date | null => {
+    let parsedDate = tryParseDate(value, pattern, referenceDate, locale);
+
+    if (!parsedDate && value.length < pattern.length) {
+        parsedDate = tryParseDate(value, pattern.slice(0, value.length), referenceDate, locale);
+    }
+
+    return parsedDate;
+};
+
+/**
+ * Create a masked value by applying delimiters based on the mask format.
+ * Supports tokens: YYYY, MM, DD, hh, mm, ss
+ */
+export const createMaskedValue = (raw: string, maskFormat: string): string => {
+    const tokenPattern = /(YYYY|MM|DD|hh|mm|ss)/g;
+    const tokens: string[] = [...maskFormat.matchAll(tokenPattern)].map((m) => m[0]);
+    const delimiters: string[] = maskFormat.replace(tokenPattern, '|').split('|').filter(Boolean);
+    const tokenLengths: number[] = tokens.map((t) => t.length);
+
+    let masked = '',
+        index = 0;
+
+    for (let i = 0; i < tokens.length; i++) {
+        const len = tokenLengths[i]!;
+        const part = raw.slice(index, index + len);
+        if (!part) break;
+        masked += part;
+        if (part.length === len && delimiters[i]) masked += delimiters[i];
+        index += len;
+    }
+
+    return masked;
+};
+
+/**
+ * Apply maximum value constraints to raw numeric input.
+ * Clamps values: MM (max 12), DD (max 31), hh (max 23), mm/ss (max 59)
+ */
+export const applyMaxValues = (raw: string, tokens: string[]): string => {
+    const maxValues: Record<string, number> = {
+        MM: 12,
+        DD: 31,
+        hh: 23,
+        mm: 59,
+        ss: 59,
+    };
+
+    let result = '',
+        index = 0;
+
+    for (let i = 0; i < tokens.length; i++) {
+        const token = tokens[i]!;
+        const len = token.length;
+        const part = raw.slice(index, index + len);
+        if (!part) break;
+
+        if (part.length < len) {
+            result += part;
+        } else {
+            let num = Number.parseInt(part, 10);
+            if (maxValues[token] && num > maxValues[token]) num = maxValues[token];
+            result += num.toString().padStart(len, '0').slice(0, len);
+        }
+
+        index += len;
+    }
+
+    return result;
+};


### PR DESCRIPTION
## Describe your changes

This PR fixes a regression introduced in v12.1.0 where using the `dp-input` slot with formats containing alphabetic tokens (like `MMM` for month abbreviation) no longer updates the model value.

**Root cause:** The `getPatternForValue` function (added in commit `572c401` to fix [#1208](https://github.com/Vuepic/vue-datepicker/issues/1208)) used `/\D+/g` to split input values. This incorrectly treated alphabetic parts like "Dec" in `18-Dec-2025` as separators instead of date values.

**Solution:** Simplified the parsing logic by:
- Trying the full pattern first
- Falling back to a sliced pattern for partial input
- Removed the complex `getPatternForValue` and `hasAlphabeticTokens` functions

**Additional improvements:**
- Extracted pure parsing functions to `useTextInputUtils.ts` for better testability
- Added comprehensive unit tests for `tryParseDate`, `parseDateWithPattern`, `createMaskedValue`, and `applyMaxValues`

**Tested scenarios:**
- `dd-MMM-yyyy` format (e.g., `18-Dec-2025`) → Model updates correctly ✅
- `dd-MM-yy` short year format (e.g., `18-12-25`) → Still works ✅
- All existing tests pass ✅

## Issue ticket number and link

Fixes [#1222](https://github.com/Vuepic/vue-datepicker/issues/1222)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test