### PR TITLE
feat(a11y): improve datepicker overlay semantics and labels

### DIFF
--- a/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { addMonths, subMonths } from 'date-fns';
+import { addMonths, format, subMonths } from 'date-fns';
 import { getMonthToggleBtn, getMonthToggleText, openMenu, selectDate } from '@/__tests__/tests-utils.ts';
 
 describe('Test Suite 1', () => {
@@ -65,6 +65,30 @@ describe('Test Suite 1', () => {
         it('Should open menu when centered is enabled', async () => {
             const dp = await openMenu({ centered: true });
             expect(dp.find('.dp__menu').exists()).toBe(true);
+        });
+    });
+
+    describe('accessibility', () => {
+        it('Should announce full date for calendar cells', async () => {
+            const dp = await openMenu({});
+            const today = new Date();
+            const cell = dp.find(`[data-test-id="dp-${format(today, 'yyyy-MM-dd')}"]`);
+
+            expect(cell.attributes('aria-label')).toBe(format(today, 'MMMM do, yyyy'));
+        });
+
+        it('Should announce full month and year in month overlay', async () => {
+            const dp = await openMenu({});
+            const today = new Date();
+            const monthToggle = getMonthToggleBtn(dp);
+
+            expect(monthToggle.attributes('aria-expanded')).toBe('false');
+            await monthToggle.trigger('click');
+            await dp.vm.$nextTick();
+
+            const monthCell = dp.find(`[data-test-id="${format(today, 'LLL')}"]`);
+            expect(monthCell.attributes('aria-label')).toBe(format(today, 'MMMM yyyy'));
+            expect(monthToggle.attributes('aria-expanded')).toBe('true');
         });
     });
 });

--- a/src/VueDatePicker/components/Common/SelectionOverlay.vue
+++ b/src/VueDatePicker/components/Common/SelectionOverlay.vue
@@ -29,6 +29,7 @@
                         :key="col.value"
                         role="gridcell"
                         :class="cellClassName"
+                        :aria-label="col.ariaLabel ?? col.text"
                         :aria-selected="col.active || undefined"
                         :aria-disabled="col.disabled || undefined"
                         :data-dp-action-element="level ?? 1"

--- a/src/VueDatePicker/components/DatePicker/DpCalendar.vue
+++ b/src/VueDatePicker/components/DatePicker/DpCalendar.vue
@@ -1,16 +1,23 @@
 <template>
     <div :class="calendarParentClass">
-        <div ref="calendar-wrap" :class="calendarWrapClass" role="grid">
-            <div class="dp__calendar_header" role="row">
-                <div v-if="weekNumbers" class="dp__calendar_header_item" role="gridcell">
+        <div
+            ref="calendar-wrap"
+            :class="calendarWrapClass"
+            role="listbox"
+            :aria-multiselectable="isMultiSelectable"
+            @keydown.capture="onCalendarKeydown"
+        >
+            <div class="dp__calendar_header" role="presentation">
+                <div v-if="weekNumbers" class="dp__calendar_header_item" role="presentation" aria-hidden="true">
                     {{ weekNumbers.label }}
                 </div>
                 <div
                     v-for="(dayVal, i) in weekDays"
                     :key="i"
                     class="dp__calendar_header_item"
-                    role="gridcell"
+                    role="presentation"
                     data-test-id="calendar-header"
+                    aria-hidden="true"
                     :aria-label="ariaLabels?.weekDay?.(i)"
                 >
                     <slot name="calendar-header" :day="dayVal" :index="i">
@@ -20,9 +27,14 @@
             </div>
             <div class="dp__calendar_header_separator"></div>
             <transition :name="transitionName" :css="!!transitions">
-                <div v-if="showCalendar" class="dp__calendar" role="rowgroup" @mouseleave="isMouseDown = false">
-                    <div v-for="(week, weekInd) in calendarWeeks" :key="weekInd" class="dp__calendar_row" role="row">
-                        <div v-if="weekNumbers" class="dp__calendar_item dp__week_num" role="gridcell">
+                <div v-if="showCalendar" class="dp__calendar" role="presentation" @mouseleave="isMouseDown = false">
+                    <div v-for="(week, weekInd) in calendarWeeks" :key="weekInd" class="dp__calendar_row" role="presentation">
+                        <div
+                            v-if="weekNumbers"
+                            class="dp__calendar_item dp__week_num"
+                            role="presentation"
+                            aria-hidden="true"
+                        >
                             <div class="dp__cell_inner">
                                 {{ getWeekNum(week.days) }}
                             </div>
@@ -32,7 +44,7 @@
                             :id="getCellId(dayVal.value)"
                             :ref="(el) => assignDayRef(el, weekInd, dayInd)"
                             :key="dayInd + weekInd"
-                            role="gridcell"
+                            role="option"
                             class="dp__calendar_item"
                             :aria-selected="
                                 (dayVal.classData.dp__active_date ||
@@ -41,7 +53,7 @@
                                 undefined
                             "
                             :aria-disabled="dayVal.classData.dp__cell_disabled || undefined"
-                            :aria-label="ariaLabels?.day?.(dayVal)"
+                            :aria-label="getDayAriaLabel(dayVal)"
                             :tabindex="!dayVal.current && rootProps.hideOffsetDates ? undefined : 0"
                             :data-test-id="getCellId(dayVal.value)"
                             :data-dp-element-active="!!dayVal.classData.dp__active_date ? 0 : undefined"
@@ -110,9 +122,10 @@
 <script lang="ts" setup>
     import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
     import { unrefElement, useSwipe } from '@vueuse/core';
-    import { getISOWeek, getWeek, set, type Day, startOfWeek, endOfWeek, eachDayOfInterval } from 'date-fns';
+    import { format, getISOWeek, getWeek, set, type Day, startOfWeek, endOfWeek, eachDayOfInterval } from 'date-fns';
 
     import { useHelperFns, useDateUtils, useContext, useFormatter } from '@/composables';
+    import { EventKey } from '@/constants';
 
     import type { UnwrapRef } from 'vue';
     import type { CalendarDay, CalendarWeek, DynamicClass, Marker } from '@/types';
@@ -143,7 +156,7 @@
         getDate,
         rootEmit,
         rootProps,
-        defaults: { transitions, config, ariaLabels, multiCalendars, weekNumbers, multiDates, ui },
+        defaults: { transitions, config, ariaLabels, multiCalendars, weekNumbers, multiDates, range, ui },
     } = useContext();
     const { isDateAfter, isDateEqual, resetDateTime, getCellId } = useDateUtils();
     const { checkKeyDown, checkStopPropagation, isTouchDevice } = useHelperFns();
@@ -163,6 +176,7 @@
         transform: '',
     });
     const tpArrowStyle = ref<{ left?: string; right?: string }>({ left: '50%' });
+    const isMultiSelectable = computed(() => range.value.enabled || multiDates.value.enabled);
 
     useSwipe(calendarWrapRef, {
         onSwipeEnd: (_ev, direction) => {
@@ -324,6 +338,50 @@
         }
     };
 
+    const onCalendarKeydown = (event: KeyboardEvent) => {
+        if (rootProps.arrowNavigation || !calendarWrapRef.value) return;
+
+        const target = event.target as HTMLElement | null;
+        if (!target) return;
+
+        const option = target.closest<HTMLElement>('.dp__calendar_item[role="option"]');
+        if (!option || !calendarWrapRef.value.contains(option)) return;
+
+        if (
+            event.key !== EventKey.arrowLeft &&
+            event.key !== EventKey.arrowRight &&
+            event.key !== EventKey.arrowUp &&
+            event.key !== EventKey.arrowDown
+        ) {
+            return;
+        }
+
+        const options = Array.from(calendarWrapRef.value.querySelectorAll<HTMLElement>('.dp__calendar_item[role="option"]'));
+        const currentIndex = options.indexOf(option);
+        if (currentIndex === -1) return;
+
+        const row = option.closest<HTMLElement>('.dp__calendar_row');
+        const columns = row ? row.querySelectorAll<HTMLElement>('.dp__calendar_item[role="option"]').length : 7;
+
+        const step =
+            event.key === EventKey.arrowUp
+                ? -columns
+                : event.key === EventKey.arrowDown
+                  ? columns
+                  : event.key === EventKey.arrowLeft
+                    ? -1
+                    : 1;
+
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+
+        const nextIndex = currentIndex + step;
+        if (nextIndex < 0 || nextIndex >= options.length) return;
+
+        options[nextIndex]?.focus();
+    };
+
     const getWeekNumber = (firstCurrentDate: CalendarDay) => {
         if (weekNumbers.value) {
             if (weekNumbers.value.type === 'local')
@@ -366,6 +424,10 @@
         } else if (multiDates.value.enabled) {
             emit('select-date', day);
         }
+    };
+
+    const getDayAriaLabel = (day: CalendarDay): string => {
+        return ariaLabels?.day?.(day) ?? format(day.value, 'MMMM do, yyyy', { locale: rootProps.locale });
     };
 
     const getDayNames = (): string[] => {

--- a/src/VueDatePicker/components/DatePicker/DpHeader.vue
+++ b/src/VueDatePicker/components/DatePicker/DpHeader.vue
@@ -46,6 +46,9 @@
                             class="dp__btn dp__month_year_select"
                             :class="{ 'dp--hidden-el': overlayOpen }"
                             :aria-label="`${type.text}-${type.ariaLabel}`"
+                            aria-haspopup="dialog"
+                            :aria-expanded="type.showSelectionGrid"
+                            :ref="(el) => setToggleRef(el as HTMLElement | null, type.type)"
                             :data-test-id="`${type.type}-toggle-overlay-${instance}`"
                             tabindex="0"
                             data-dp-action-element="0"
@@ -126,6 +129,7 @@
 
 <script lang="ts" setup>
     import { computed, onMounted, ref, type Ref } from 'vue';
+    import { format, set } from 'date-fns';
 
     import {
         CalendarIcon,
@@ -172,6 +176,7 @@
     const props = defineProps<DpHeaderProps>();
 
     const {
+        getDate,
         rootEmit,
         rootProps,
         modelValue,
@@ -190,6 +195,8 @@
     const showMonthPicker = ref(false);
     const showYearPicker = ref(false);
     const overlayOpen = ref(false);
+    const monthToggleRef = ref<HTMLElement | null>(null);
+    const yearToggleRef = ref<HTMLElement | null>(null);
 
     onMounted(() => {
         emit('mount');
@@ -229,6 +236,8 @@
 
     const groupedMonths = computed((): OverlayGridItem[][] => {
         return groupListAndMap(props.months, (month: SelectItem) => {
+            const monthDate = set(getDate(), { year: props.year, month: month.value, date: 1 });
+            const ariaLabel = format(monthDate, 'MMMM yyyy', { locale: rootProps.locale });
             const active = props.month === month.value;
             const disabled =
                 checkMinMaxValue(
@@ -237,12 +246,13 @@
                     getMaxMonth(props.year, safeDates.value.maxDate),
                 ) || filters.value.months.includes(month.value);
             const highlighted = checkHighlightMonth(highlight.value, month.value, props.year);
-            return { active, disabled, highlighted };
+            return { active, disabled, highlighted, ariaLabel };
         });
     });
 
     const groupedYears = computed((): OverlayGridItem[][] => {
         return groupListAndMap(props.years, (year: SelectItem) => {
+            const ariaLabel = formatYear(year.value);
             const active = props.year === year.value;
             const disabled =
                 checkMinMaxValue(
@@ -251,11 +261,20 @@
                     getYearFromDate(safeDates.value.maxDate),
                 ) || filters.value.years.includes(year.value);
             const highlighted = checkHighlightYear(highlight.value, year.value);
-            return { active, disabled, highlighted };
+            return { active, disabled, highlighted, ariaLabel };
         });
     });
 
-    const toggleWrap = (val: Ref<boolean>, type: FlowStep, show?: boolean) => {
+    const focusToggle = (type: HeaderPicker) => {
+        const target = type === HeaderPicker.month ? monthToggleRef.value : yearToggleRef.value;
+        if (target) {
+            requestAnimationFrame(() => {
+                target.focus({ preventScroll: true });
+            });
+        }
+    };
+
+    const toggleWrap = (val: Ref<boolean>, type: FlowStep, pickerType: HeaderPicker, show?: boolean) => {
         if (show === undefined) {
             val.value = !val.value;
         } else {
@@ -268,22 +287,31 @@
         } else {
             overlayOpen.value = false;
             rootEmit('overlay-toggle', { open: false, overlay: type });
+            focusToggle(pickerType);
         }
     };
 
     const toggleMonthPicker = (flow = false, show?: boolean): void => {
         checkFlow(flow);
-        toggleWrap(showMonthPicker, FlowStep.month, show);
+        toggleWrap(showMonthPicker, FlowStep.month, HeaderPicker.month, show);
     };
 
     const toggleYearPicker = (flow = false, show?: boolean): void => {
         checkFlow(flow);
-        toggleWrap(showYearPicker, FlowStep.year, show);
+        toggleWrap(showYearPicker, FlowStep.year, HeaderPicker.year, show);
     };
 
     const checkFlow = (flow: boolean): void => {
         if (!flow) {
             emit('reset-flow');
+        }
+    };
+
+    const setToggleRef = (el: HTMLElement | null, type: HeaderPicker) => {
+        if (type === HeaderPicker.month) {
+            monthToggleRef.value = el;
+        } else {
+            yearToggleRef.value = el;
         }
     };
 

--- a/src/VueDatePicker/components/MonthPicker/useMonthPicker.ts
+++ b/src/VueDatePicker/components/MonthPicker/useMonthPicker.ts
@@ -1,5 +1,5 @@
 import { computed, type EmitFn, nextTick, onMounted, ref } from 'vue';
-import { getMonth, getYear, set } from 'date-fns';
+import { format, getMonth, getYear, set } from 'date-fns';
 
 import { useContext, useDateUtils, useRemapper, useHelperFns, useUtilsWithContext, useValidation } from '@/composables';
 import { useMonthOrQuarterPicker } from '@/components/shared/useMonthQuarterPicker.ts';
@@ -106,6 +106,8 @@ export const useMonthPicker = (props: BaseProps, emit: EmitFn<MonthPickerEmits>)
 
     const groupedMonths = computed(() => (instance: number): OverlayGridItem[][] => {
         return groupListAndMap(months.value, (month) => {
+            const monthDate = set(resetDate(getDate()), { month: month.value, year: year.value(instance) });
+            const ariaLabel = format(monthDate, 'MMMM yyyy', { locale: rootProps.locale });
             const active = checkActiveMonth(instance, month.value);
             const disabled =
                 checkMinMaxValue(
@@ -119,7 +121,7 @@ export const useMonthPicker = (props: BaseProps, emit: EmitFn<MonthPickerEmits>)
                 isOutOfYearRange(year.value(instance));
             const isBetween = isMonthBetween(month.value, instance);
             const highlighted = checkHighlightMonth(highlight.value, month.value, year.value(instance));
-            return { active, disabled, isBetween, highlighted };
+            return { active, disabled, isBetween, highlighted, ariaLabel };
         });
     });
 

--- a/src/VueDatePicker/components/TimePicker/TimeInput.vue
+++ b/src/VueDatePicker/components/TimePicker/TimeInput.vue
@@ -366,6 +366,13 @@
             generatedArray.unshift({ value: amPm.value === 'PM' ? 12 : 0, text: '12' });
         }
 
+        const toAriaLabel = (value: SelectItem) => {
+            const unit = type === 'hours' ? 'hour' : type === 'minutes' ? 'minute' : 'second';
+            const count = Number(value.text);
+            const labelUnit = count === 1 ? unit : `${unit}s`;
+            return `${value.text} ${labelUnit}`;
+        };
+
         return groupListAndMap(generatedArray, (value: SelectItem) => {
             const active = false;
             const disabled =
@@ -374,7 +381,7 @@
                 isValueDisabled(type, value.value) ||
                 isOverlayValueDisabled(type, value.value);
 
-            return { active, disabled };
+            return { active, disabled, ariaLabel: toAriaLabel(value) };
         });
     };
 

--- a/src/VueDatePicker/components/YearPicker/useYearPicker.ts
+++ b/src/VueDatePicker/components/YearPicker/useYearPicker.ts
@@ -1,7 +1,7 @@
 import { computed, type EmitFn, nextTick, onMounted, ref } from 'vue';
 import { getYear, setYear, startOfYear } from 'date-fns';
 
-import { useContext, useDateUtils, useRemapper, useUtilsWithContext, useValidation } from '@/composables';
+import { useContext, useDateUtils, useFormatter, useRemapper, useUtilsWithContext, useValidation } from '@/composables';
 import { useComponentShared } from '@/components/shared/useComponentShared.ts';
 import type { BaseProps } from '@/types';
 
@@ -22,6 +22,7 @@ export const useYearPicker = (props: BaseProps, emit: EmitFn<YearPickerEmits>) =
     const { getYears } = useUtilsWithContext();
     const { isDateBetween, resetDate, resetDateTime, getYearFromDate, checkHighlightYear, groupListAndMap } =
         useDateUtils();
+    const { formatYear } = useFormatter();
     const { checkRangeAutoApply, setMonthOrYearRange } = useComponentShared();
     const { checkMinMaxValue, checkMinMaxRange } = useValidation();
 
@@ -73,6 +74,7 @@ export const useYearPicker = (props: BaseProps, emit: EmitFn<YearPickerEmits>) =
 
     const groupedYears = computed(() => {
         return groupListAndMap(getYears(), (year) => {
+            const ariaLabel = formatYear(year.value);
             const active = isYearActive(year.value);
             const disabled =
                 checkMinMaxValue(
@@ -85,7 +87,7 @@ export const useYearPicker = (props: BaseProps, emit: EmitFn<YearPickerEmits>) =
                 isYearDisabled(year.value);
             const isBetween = isYearBetween(year.value) && !active;
             const highlighted = checkHighlightYear(highlight.value, year.value);
-            return { active, disabled, isBetween, highlighted };
+            return { active, disabled, isBetween, highlighted, ariaLabel };
         });
     });
 

--- a/src/VueDatePicker/components/shared/useMonthQuarterPicker.ts
+++ b/src/VueDatePicker/components/shared/useMonthQuarterPicker.ts
@@ -2,7 +2,7 @@ import { computed, type EmitFn, onMounted, ref, watch } from 'vue';
 import { addYears, differenceInYears, endOfYear, getMonth, getYear, set, startOfYear, subYears } from 'date-fns';
 
 import { FlowStep } from '@/constants';
-import { useContext, useDateUtils, useUtilsWithContext, useValidation } from '@/composables';
+import { useContext, useDateUtils, useFormatter, useUtilsWithContext, useValidation } from '@/composables';
 
 import type { OverlayGridItem, SelectItem } from '@/types';
 
@@ -22,6 +22,7 @@ export const useMonthOrQuarterPicker = (emit: EmitFn<{ 'reset-flow': []; 'auto-a
         defaults: { multiCalendars, range, safeDates, filters, highlight },
     } = useContext();
     const { resetDate, getYearFromDate, checkHighlightYear, groupListAndMap } = useDateUtils();
+    const { formatYear } = useFormatter();
     const { getYears } = useUtilsWithContext();
     const { validateMonthYear, checkMinMaxValue } = useValidation();
 
@@ -112,6 +113,7 @@ export const useMonthOrQuarterPicker = (emit: EmitFn<{ 'reset-flow': []; 'auto-a
 
     const groupedYears = computed(() => (instance: number): OverlayGridItem[][] => {
         return groupListAndMap(years.value, (y: SelectItem) => {
+            const ariaLabel = formatYear(y.value);
             const active = year.value(instance) === y.value;
             const disabled =
                 checkMinMaxValue(
@@ -121,7 +123,7 @@ export const useMonthOrQuarterPicker = (emit: EmitFn<{ 'reset-flow': []; 'auto-a
                 ) || filters.value.years?.includes(year.value(instance));
             const highlighted = checkHighlightYear(highlight.value, y.value);
 
-            return { active, disabled, highlighted };
+            return { active, disabled, highlighted, ariaLabel };
         });
     });
 

--- a/src/VueDatePicker/composables/useDateUtils.ts
+++ b/src/VueDatePicker/composables/useDateUtils.ts
@@ -199,11 +199,12 @@ export const useDateUtils = () => {
             disabled: boolean;
             highlighted?: boolean;
             isBetween?: boolean;
+            ariaLabel?: string;
         },
     ): OverlayGridItem[][] => {
         return getGroupedList(list).map((items) => {
             return items.map((item) => {
-                const { active, disabled, isBetween, highlighted } = cb(item);
+                const { active, disabled, isBetween, highlighted, ariaLabel } = cb(item);
                 return {
                     ...item,
                     active,
@@ -217,6 +218,7 @@ export const useDateUtils = () => {
                         dp__cell_in_between: isBetween,
                         'dp--highlighted': highlighted,
                     },
+                    ariaLabel,
                 };
             });
         });

--- a/src/VueDatePicker/types/generic.ts
+++ b/src/VueDatePicker/types/generic.ts
@@ -47,6 +47,7 @@ export interface OverlayGridItem {
     active: boolean;
     disabled: boolean;
     className: DynamicClass;
+    ariaLabel?: string;
 }
 
 export type Numeric = number | string | null;


### PR DESCRIPTION
## Describe your changes
- Updated calendar semantics to use listbox/option roles and cleaned up row/header roles.
- Added full date aria-labels for day cells (e.g., “January 8th, 2026”).
- Added explicit aria-labels for month/year/time overlay items.
- Ensured month/year toggle buttons expose aria-expanded/haspopup and regain focus when overlays close.
- Added unit tests covering calendar and month overlay aria-labels.

## Issue ticket number and link
- Partially addresses #1211

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test