### PR TITLE
chore: fix missing style sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "run-s clean type-check build:es build:css",
     "type-check": "vue-tsc --build",
     "build:es": "cross-env NODE_ENV=production vite build --mode production",
-    "build:css": "cross-env NODE_ENV=production node_modules/.bin/sass src/VueDatePicker/style/main.scss dist/main.css --style compressed",
+    "build:css": "cross-env NODE_ENV=production node_modules/.bin/sass src/VueDatePicker/style/main.scss dist/main.css --style compressed --embed-sources",
     "build:for-docs": "run-s build docs:copy-build",
     "test": "cross-env NODE_ENV=test vitest",
     "test:coverage": "cross-env NODE_ENV=test vitest --environment jsdom run --coverage",


### PR DESCRIPTION
## Describe your changes
Embed sources in the source map to fix a warning when using vue-datepicker with Vite.

```bash
$ vite

> Sourcemap for "/../my-vue-project/node_modules/@vuepic/vue-datepicker/dist/main.css" points to missing source files
```

## Issue ticket number and link
Fixes #1226

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test