### PR TITLE
docs: remove outdated tip about date-fns locale re-export

### DIFF
--- a/docs/props/formatting/index.md
+++ b/docs/props/formatting/index.md
@@ -19,10 +19,6 @@ Formats prop allows configuring the format of various picker elements
 - All formating is based on the provided [`locale`](/props/localization/#locale) prop
 :::
 
-:::tip
-For convenience, the library provides re-export from `date-fns` for all supported locales`
-:::
-
 - Type:
 ```ts
 interface FormatsConfig {


### PR DESCRIPTION
## Describe your changes

It looks like locales should be imported from `date-fns/locale` directly. There isn't a re-export anymore.

https://vue3datepicker.com/migration/from-v11#locale

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test