### PR TITLE
fix(#1256): update time model when range switches when menu is close

### DIFF
--- a/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { addMonths, subMonths } from 'date-fns';
-import { getMonthToggleBtn, getMonthToggleText, openMenu, selectDate } from '@/__tests__/tests-utils.ts';
+import { getMonthToggleBtn, getMonthToggleText, openMenu, selectDate, clearInput } from '@/__tests__/tests-utils.ts';
+import { flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
 
 describe('Test Suite 1', () => {
     describe('multi-calendars', () => {
@@ -65,6 +67,40 @@ describe('Test Suite 1', () => {
         it('Should open menu when centered is enabled', async () => {
             const dp = await openMenu({ centered: true });
             expect(dp.find('.dp__menu').exists()).toBe(true);
+        });
+    });
+
+    describe('range toggle', () => {
+        const frozenSystemDate = new Date(2026, 2, 15, 12, 30, 30);
+        beforeEach(() => {
+            vi.setSystemTime(frozenSystemDate);
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('Should allow selecting single date after disabling range while menu is closed.', async () => {
+            const startDate = new Date(2026, 2, 1);
+            const endDate = new Date(2026, 2, 15);
+            const dp = await openMenu({ range: true, modelValue: [startDate, endDate] });
+
+            dp.vm.closeMenu();
+            await nextTick();
+            clearInput(dp);
+            await nextTick();
+
+            await dp.setProps({ range: false, modelValue: null });
+
+            dp.vm.openMenu();
+            await nextTick();
+
+            const dateToSelect = new Date(2026, 2, 18);
+            const expectedModelDate = new Date(dateToSelect.getFullYear(), dateToSelect.getMonth(), dateToSelect.getDate(), frozenSystemDate.getHours(), frozenSystemDate.getMinutes(), 0);
+            await selectDate(dp, dateToSelect);
+            await nextTick();
+
+            expect(dp.emitted('date-click')![0]![0]).toEqual(expectedModelDate);
         });
     });
 });

--- a/src/VueDatePicker/__tests__/tests-utils.ts
+++ b/src/VueDatePicker/__tests__/tests-utils.ts
@@ -26,3 +26,7 @@ export const selectDate = async (dp: DPInstance, date: Date) => {
 export const getMonthToggleText = (date: Date) => {
     return format(date, 'LLL');
 };
+
+export const clearInput = (dp: DPInstance) => {
+    return dp.find(`[data-test-id="clear-input-value-btn"]`).trigger('click');
+};

--- a/src/VueDatePicker/components/DatePicker/useDatePicker.ts
+++ b/src/VueDatePicker/components/DatePicker/useDatePicker.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, ref, nextTick, type EmitFn, type UnwrapRef } from 'vue';
+import { computed, onMounted, ref, nextTick, type EmitFn, type UnwrapRef, watch } from 'vue';
 import {
     add,
     addDays,
@@ -61,7 +61,7 @@ export const useDatePicker = (
     const { formatDay } = useFormatter();
     const { resetDateTime, setTime, isDateBefore, isDateEqual, getDaysInBetween } = useDateUtils();
     const { checkRangeAutoApply, getRangeWithFixedDate, handleMultiDatesSelect, setPresetDate } = useComponentShared();
-    const { getMapDate } = useHelperFns();
+    const { getMapDate, setTimeModelValue } = useHelperFns();
     useRemapper(() => mapInternalModuleValues(state.isTextInputDate));
 
     const shouldUpdateMonthView = (isAction: boolean) => {
@@ -402,7 +402,7 @@ export const useDatePicker = (
     // Called on selectDate when the regular single picker is used
     const handleSingleDateSelect = (day: CalendarDay) => {
         const date = setTime(
-            { hours: time.hours as number, minutes: time.minutes as number, seconds: getSecondsValue() },
+            { hours: time.hours, minutes: time.minutes, seconds: getSecondsValue() },
             getDate(day.value),
         );
         rootEmit('date-click', date);

--- a/src/VueDatePicker/composables/useExternalInternalMapper.ts
+++ b/src/VueDatePicker/composables/useExternalInternalMapper.ts
@@ -36,6 +36,7 @@ export const useExternalInternalMapper = () => {
     watch(range, (newVal, oldVal) => {
         if (newVal.enabled !== oldVal.enabled) {
             modelValue.value = null;
+            updateTime(); // Ensure time model switches from plain to array when range changes.
         }
     });
 

--- a/src/VueDatePicker/composables/useRemapper.ts
+++ b/src/VueDatePicker/composables/useRemapper.ts
@@ -4,22 +4,8 @@ import { useContext, useHelperFns } from '@/composables';
 
 export const useRemapper = (reMap?: () => void) => {
     const {
-        today,
-        time,
         modelValue,
-        defaults: { range },
     } = useContext();
-    const { setTimeModelValue } = useHelperFns();
-
-    watch(
-        range,
-        (newVal, oldVal) => {
-            if (newVal.enabled !== oldVal.enabled) {
-                setTimeModelValue(time, modelValue.value, today, range.value.enabled);
-            }
-        },
-        { deep: true },
-    );
 
     watch(
         modelValue,


### PR DESCRIPTION
## Describe your changes

The time model value was updating only when the menu was open, because the composable handling this was only running when the menu was open.

I've moved this update to another composable, which lives even when the menu is closed. This prevents having inconsistent time model type, which was causing the exception in #1256 .

I have added a non-regression unit test which reproduced the error (reverting the fix makes the test fail, which proves it tests exactly this case).

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test