### PR TITLE
fix(useFormatter.ts): remove extra spaces around rangeSeparator on focus

### DIFF
--- a/src/VueDatePicker/composables/useFormatter.ts
+++ b/src/VueDatePicker/composables/useFormatter.ts
@@ -53,7 +53,7 @@ export const useFormatter = () => {
     const formatRangeTextInput = () => {
         const formatter = (value: Date) => format(value, textInput.value.format as string);
         if (Array.isArray(modelValue.value)) {
-            return `${formatter(modelValue.value[0]!)} ${textInput.value.rangeSeparator} ${
+            return `${formatter(modelValue.value[0]!)}${textInput.value.rangeSeparator}${
                 modelValue.value[1] ? formatter(modelValue.value[1]) : ''
             }`;
         }


### PR DESCRIPTION
The formatRangeTextInput function was adding extra spaces around the rangeSeparator when the input received focus, causing inconsistent spacing between focus and blur states.

Fixes the issue where '04/08/2026, 16:58 - 04/16/2026, 16:58' became '04/08/2026, 16:58  -  04/16/2026, 16:58' on focus.

## Describe your changes

Removed extra spaces around `textInput.value.rangeSeparator` in the `formatRangeTextInput()` function (`useFormatter.ts`). The function was wrapping the separator with spaces (` ${separator} `), while `formatSelectedDate()` does not. This caused inconsistent spacing between focus and blur states.

**Before:** `"04/08/2026, 16:58  -  04/16/2026, 16:58"` (double spaces on focus)
**After:** `"04/08/2026, 16:58 - 04/16/2026, 16:58"` (consistent with blur state)

## Issue ticket number and link

Closes #1269 - https://github.com/Vuepic/vue-datepicker/issues/1269

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test