### PR TITLE
fix: week-picker mode doesn't work properly with multi-dates prop (re…

### DIFF
--- a/src/VueDatePicker/components/DatePicker/useCalendarClass.ts
+++ b/src/VueDatePicker/components/DatePicker/useCalendarClass.ts
@@ -307,6 +307,27 @@ export const useCalendarClass = () => {
         };
     };
 
+    // Get a set of classes for the week picker with multi-dates
+    const weekPickerMultiDatesClasses = (day: CalendarDay): Record<string, boolean> => {
+        if (modelValue.value && Array.isArray(modelValue.value)) {
+            const matchingWeek = (modelValue.value as Date[]).find((date) => {
+                const [start, end] = getWeekFromDate(date, rootProps.weekStart);
+                return isDateEqual(day.value, start) || isDateEqual(day.value, end) ||
+                    (isDateAfter(day.value, start) && isDateBefore(day.value, end));
+            });
+            if (matchingWeek) {
+                const [start, end] = getWeekFromDate(matchingWeek, rootProps.weekStart);
+                return {
+                    ...autoRangeClasses(day),
+                    dp__range_start: isDateEqual(start, day.value),
+                    dp__range_end: isDateEqual(end, day.value),
+                    dp__range_between_week: isDateAfter(day.value, start) && isDateBefore(day.value, end),
+                };
+            }
+        }
+        return { ...autoRangeClasses(day) };
+    };
+
     // Get a set of classes for the single-week picker
     const weekPickerSingleClasses = (day: CalendarDay): Record<string, boolean> => {
         if (modelValue.value && !Array.isArray(modelValue.value)) {
@@ -440,6 +461,7 @@ export const useCalendarClass = () => {
             return rangeDateClasses(day);
         }
         if (rootProps.weekPicker) {
+            if (multiDates.value.enabled) return weekPickerMultiDatesClasses(day);
             return weekPickerSingleClasses(day);
         }
 

--- a/src/VueDatePicker/components/DatePicker/useDatePicker.ts
+++ b/src/VueDatePicker/components/DatePicker/useDatePicker.ts
@@ -59,7 +59,7 @@ export const useDatePicker = (
     const { updateTimeValues, getSetDateTime, assignTime, assignStartTime, validateTime, disabledTimesConfig } =
         useTimePickerUtils(updateFlow);
     const { formatDay } = useFormatter();
-    const { resetDateTime, setTime, isDateBefore, isDateEqual, getDaysInBetween } = useDateUtils();
+    const { resetDateTime, setTime, isDateBefore, isDateEqual, getDaysInBetween, getWeekFromDate } = useDateUtils();
     const { checkRangeAutoApply, getRangeWithFixedDate, handleMultiDatesSelect, setPresetDate } = useComponentShared();
     const { getMapDate } = useHelperFns();
     useRemapper(() => mapInternalModuleValues(state.isTextInputDate));
@@ -401,9 +401,14 @@ export const useDatePicker = (
 
     // Called on selectDate when the regular single picker is used
     const handleSingleDateSelect = (day: CalendarDay) => {
+        let dateToSelect = getDate(day.value);
+        if (rootProps.weekPicker && multiDates.value.enabled) {
+            const [weekStart] = getWeekFromDate(dateToSelect, rootProps.weekStart);
+            dateToSelect = weekStart;
+        }
         const date = setTime(
             { hours: time.hours as number, minutes: time.minutes as number, seconds: getSecondsValue() },
-            getDate(day.value),
+            dateToSelect,
         );
         rootEmit('date-click', date);
         if (multiDates.value.enabled) {

--- a/src/VueDatePicker/composables/useExternalInternalMapper.ts
+++ b/src/VueDatePicker/composables/useExternalInternalMapper.ts
@@ -126,6 +126,19 @@ export const useExternalInternalMapper = () => {
         throw new Error(errorMapper.dateArr('multi-dates'));
     };
 
+    // Map external week picker + multi dates format to internal model value
+    const mapWeekMultiDatesExternalToInternal = (value: any): Date[] => {
+        if (Array.isArray(value)) {
+            return value.map((week: any) => {
+                if (Array.isArray(week) && week.length) {
+                    return parseModelType(week[0]);
+                }
+                return parseModelType(week);
+            });
+        }
+        throw new Error(errorMapper.dateArr('multi-dates'));
+    };
+
     // Map external week picker format to internal model value
     const mapWeekExternalToInternal = (value: Date[]) => {
         if (Array.isArray(value) && range.value.enabled) {
@@ -210,6 +223,7 @@ export const useExternalInternalMapper = () => {
         if (rootProps.timePicker) return mapTimeExternalToInternal(convertType(value));
         if (rootProps.monthPicker) return mapMonthExternalToInternal(convertType(value));
         if (rootProps.yearPicker) return mapYearExternalToInternal(convertType(value));
+        if (rootProps.weekPicker && multiDates.value.enabled) return mapWeekMultiDatesExternalToInternal(convertType(value));
         if (multiDates.value.enabled) return mapMultiDateExternalToInternal(convertType(value));
         if (rootProps.weekPicker) return mapWeekExternalToInternal(convertType(value));
         return mapDateExternalToInternal(convertType(value));
@@ -235,6 +249,12 @@ export const useExternalInternalMapper = () => {
     // Get proper input value depending on the mode
     const getInputValue = (): string => {
         if (!modelValue.value) return '';
+        if (rootProps.weekPicker && multiDates.value.enabled) {
+            return (modelValue.value as Date[]).map((date) => {
+                const [start, end] = getWeekFromDate(date, rootProps.weekStart);
+                return formatSelectedDate([start, end]);
+            }).join('; ');
+        }
         if (multiDates.value.enabled)
             return (modelValue.value as Date[]).map((date) => formatSelectedDate(date)).join('; ');
         if (textInput.value.enabled) return formatForTextInput();
@@ -310,6 +330,14 @@ export const useExternalInternalMapper = () => {
         return rootEmit('update:model-value', mapInternalWeekPickerToExternal());
     };
 
+    const emitWeekMultiDates = () => {
+        const dates = (modelValue.value as Date[]) || [];
+        const weekRanges = dates.map((date) =>
+            getWeekFromDate(date, rootProps.weekStart).map((d) => toModelType(d))
+        );
+        return emitValue(weekRanges as any);
+    };
+
     /**
      * When date is selected, emit event to update modelValue on external,
      * and format input value
@@ -320,6 +348,7 @@ export const useExternalInternalMapper = () => {
         if (rootProps.monthPicker) return modeEmitter(getMonthVal);
         if (rootProps.timePicker) return modeEmitter(getTimeVal);
         if (rootProps.yearPicker) return modeEmitter(getYear);
+        if (rootProps.weekPicker && multiDates.value.enabled) return emitWeekMultiDates();
         if (rootProps.weekPicker) return emitWeekPicker();
         return emitValue(mapInternalDatesToExternal());
     };

--- a/src/VueDatePicker/composables/useValidation.ts
+++ b/src/VueDatePicker/composables/useValidation.ts
@@ -373,7 +373,7 @@ export const useValidation = () => {
 
     const isValidDate = (value: Date | Date[] | null | (Date | null)[]): boolean => {
         if (Array.isArray(value)) {
-            return isValid(value[0]) && (value[1] ? isValid(value[1]) : true);
+            return value.every((v) => v === null || isValid(v));
         }
         return value ? isValid(value) : false;
     };


### PR DESCRIPTION
Fixes #1260 

## Describe your changes
- Highlight all selected weeks via dedicated multi-dates class resolver
- Normalize clicked day to week start so toggling the same week works
- Map external Date[][] format for week-picker + multi-dates
- Format input as joined week ranges
- Validate every element of multi-dates arrays
- 
## Issue ticket number and link
#1260 

## Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [x ] I have ensured that unit tests pass without errors
- [ ] If it is a new feature, I have added a new unit test