### PR TITLE
fix(menu): menu wrap remains in the DOM after the menu itself is closed

### DIFF
--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -20,6 +20,7 @@
         </DatepickerInput>
         <TeleportCmp :to="teleport" :disabled="!teleport">
             <div
+                v-if="isOpen"
                 ref="dp-menu-wrap"
                 :class="{
                     'dp--menu-wrapper': !inline.enabled,
@@ -33,7 +34,7 @@
                     :css="showTransition && !inline.enabled && !rootProps.centered && shouldRender"
                 >
                     <DatepickerMenu
-                        v-if="isOpen && shouldRender"
+                        v-if="shouldRender"
                         ref="dp-menu"
                         :class="{ [theme]: true }"
                         :no-overlay-focus="noOverlayFocus"

--- a/src/VueDatePicker/VueDatePicker.vue
+++ b/src/VueDatePicker/VueDatePicker.vue
@@ -20,7 +20,7 @@
         </DatepickerInput>
         <TeleportCmp :to="teleport" :disabled="!teleport">
             <div
-                v-if="isOpen"
+                v-if="shouldRenderMenuWrap"
                 ref="dp-menu-wrap"
                 :class="{
                     'dp--menu-wrapper': !inline.enabled,
@@ -31,10 +31,12 @@
             >
                 <transition
                     :name="menuTransition(placement.startsWith('top'))"
+                    appear
                     :css="showTransition && !inline.enabled && !rootProps.centered && shouldRender"
+                    @after-leave="onMenuAfterLeave"
                 >
                     <DatepickerMenu
-                        v-if="shouldRender"
+                        v-if="isOpen && shouldRender"
                         ref="dp-menu"
                         :class="{ [theme]: true }"
                         :no-overlay-focus="noOverlayFocus"
@@ -116,6 +118,7 @@
 
     const slots = useSlots();
     const isOpen = ref(false);
+    const shouldRenderMenuWrap = ref(inline.value.enabled);
     const shouldRender = ref(inline.value.enabled || rootProps.centered);
     const modelValueRef = toRef(rootProps, 'modelValue');
     const timezoneRef = toRef(rootProps, 'timezone');
@@ -261,6 +264,7 @@
     const openMenu = () => {
         if (!rootProps.disabled && !rootProps.readonly) {
             watchRender.value = true;
+            shouldRenderMenuWrap.value = true;
             isOpen.value = true;
 
             if (isOpen.value) {
@@ -365,6 +369,12 @@
             }
             clearInternalValues();
             rootEmit('blur');
+        }
+    };
+
+    const onMenuAfterLeave = () => {
+        if (!inline.value.enabled && !isOpen.value) {
+            shouldRenderMenuWrap.value = false;
         }
     };
 

--- a/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { addMonths, subMonths } from 'date-fns';
-import { getMonthToggleBtn, getMonthToggleText, openMenu, selectDate, clearInput } from '@/__tests__/tests-utils.ts';
-import { flushPromises } from '@vue/test-utils';
+import { getMonthToggleBtn, getMonthToggleText, openMenu, closeMenu, selectDate, clearInput } from '@/__tests__/tests-utils.ts';
 import { nextTick } from 'vue';
 
 describe('Test Suite 1', () => {
@@ -103,4 +102,14 @@ describe('Test Suite 1', () => {
             expect(dp.emitted('date-click')![0]![0]).toEqual(expectedModelDate);
         });
     });
+
+    describe('DOM', () => {
+        it('Should render menu wrap only while menu is open', async () => {
+            const dpOpenedMenu = await openMenu({});
+            expect(dpOpenedMenu.vm.dpWrapMenuRef()?.value).toBeTruthy();
+
+            const dpClosedMenu = await closeMenu({});
+            expect(dpClosedMenu.vm.dpWrapMenuRef()?.value).toBeNull();
+        });
+    })
 });

--- a/src/VueDatePicker/__tests__/tests-utils.ts
+++ b/src/VueDatePicker/__tests__/tests-utils.ts
@@ -15,6 +15,16 @@ export const openMenu = async (props: Partial<RootProps>): Promise<DPInstance> =
     return dp;
 };
 
+export const closeMenu = async (props: Partial<RootProps>): Promise<DPInstance> => {
+    const dp = mount(VueDatePickerRoot, { props });
+
+    dp.vm.closeMenu();
+    await flushPromises();
+
+    await dp.vm.$nextTick();
+    return dp;
+};
+
 export const getMonthToggleBtn = (dp: DPInstance, index = 0) => {
     return dp.find(`[data-test-id="month-toggle-overlay-${index}"]`);
 };


### PR DESCRIPTION
## Describe your changes
I've added conditional rendering for the menu wrap. The menu wrap is only rendered if the menu itself is open.

I've also added tests to check the menu wrap state.

## Issue ticket number and link

Closes #1278

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] If it is a new feature, I have added a new unit test