### PR TITLE
fix: update-month-year event not emitted when navigating to January

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -119,6 +119,21 @@ describe('Test Suite 1', () => {
     });
   });
 
+  describe('Events', () => {
+    it('Should emit update-month-year when navigating to January', async () => {
+      const dp = await openMenu({ modelValue: new Date(2025, 1, 15) }); // February 2025
+      await nextTick();
+
+      await dp.find(`[data-dp-element="action-prev"]`).trigger('click');
+      await nextTick();
+
+      const emitted = dp.emitted('update-month-year');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![emitted!.length - 1][0]).toEqual({ month: 0, year: 2025, instance: 0 });
+    });
+  });
+
   describe('DOM', () => {
     it('Should render menu wrap only while menu is open', async () => {
       const dpOpenedMenu = await openMenu({});

--- a/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
+++ b/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
@@ -73,7 +73,7 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
     isAction: boolean = false,
   ): void => {
     if (shouldUpdateMonthView(isAction)) {
-      if (!fromMount && month && year) emitMonthYearChange(instance, month, year);
+      if (!fromMount && month !== null && year !== null) emitMonthYearChange(instance, month, year);
       calendars.value[instance] ??= calendars.value[instance] = { month: 0, year: 0 };
       calendars.value[instance].month = month ?? calendars.value[instance]?.month;
       calendars.value[instance].year = year ?? calendars.value[instance]?.year;


### PR DESCRIPTION
## Summary

Fixes #1288.

`@update-month-year` was never emitted when navigation landed on January (month index `0`), because the guard in `setCalendarMonthYear()` used truthiness instead of a null check:

```ts
// packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
if (!fromMount && month && year) emitMonthYearChange(instance, month, year);
```

Months are 0-indexed internally (January = `0`), so `month && year` short-circuits to `false` whenever `month === 0` — `emitMonthYearChange` (and therefore the `update-month-year` emit) is silently skipped for every navigation into January, even though the calendar itself renders correctly. This makes it impossible to keep external state in sync with the displayed month using this event whenever January is involved.

`month`/`year` are typed `number | null` and are otherwise handled with explicit `??`/equality checks elsewhere in the same function (e.g. the `??` merge two lines below), so the truthy check here looks like the one place that slipped through.

## Fix

```ts
if (!fromMount && month !== null && year !== null) emitMonthYearChange(instance, month, year);
```

## How I found and verified this

- Traced the reporter's `dist` stack trace back to source: `packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts:76`.
- Added a regression test (`Events > Should emit update-month-year when navigating to January`) that mounts the picker on February 2025, clicks the previous-month button, and asserts the emitted `update-month-year` payload is `{ month: 0, year: 2025, instance: 0 }`.
- Confirmed RED: with the guard unchanged, the test fails with `expected undefined to be truthy` (no `update-month-year` event recorded at all).
- Applied the one-line fix, confirmed GREEN: the full `TestSuite_1.spec.ts` (14/14) passes.
- Ran the full package test suite, `oxlint`, and `vue-tsc --build --force` — all clean.

## Test plan

- [x] `pnpm --filter @vuepic/vue-datepicker test` — 14/14 pass, including the new regression test
- [x] `pnpm --filter @vuepic/vue-datepicker` `oxlint src` — no errors
- [x] `vue-tsc --build --force` — no type errors
