### PR TITLE
Fix Allow to delate backslash when used keyboard

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -119,6 +119,41 @@ describe('Test Suite 1', () => {
     });
   });
 
+  describe('text input', () => {
+    it('Should allow deleting a date separator with mask and auto apply enabled', async () => {
+      const minYr = 2013;
+      const maxYr = 3026;
+      const minDate = new Date(minYr, 0, 1);
+      const maxDate = new Date();
+      maxDate.setFullYear(maxYr);
+
+      const dp = await openMenu({
+        modelValue: minDate,
+        autoApply: true,
+        minDate,
+        maxDate,
+        yearRange: [minYr, maxYr],
+        textInput: {
+          format: 'dd/MM/yyyy',
+          maskFormat: 'DD/MM/YYYY',
+          applyOnBlur: true,
+        },
+        timeConfig: {
+          enableTimePicker: false,
+        },
+      });
+
+      const input = dp.find(`[data-test-id="dp-input"]`);
+      await input.trigger('focus');
+      await nextTick();
+
+      await input.setValue('01/01/');
+      await input.setValue('01/01');
+
+      expect((input.element as HTMLInputElement).value).toEqual('01/01');
+    });
+  });
+
   describe('DOM', () => {
     it('Should render menu wrap only while menu is open', async () => {
       const dpOpenedMenu = await openMenu({});

--- a/packages/lib/src/VueDatePicker/components/DatePickerInput/DatepickerInput.vue
+++ b/packages/lib/src/VueDatePicker/components/DatePickerInput/DatepickerInput.vue
@@ -213,7 +213,7 @@
 
       const adjustedRaw = applyMaxValues(raw, tokens);
 
-      parsedValue = createMaskedValue(adjustedRaw, maskFormat);
+      parsedValue = createMaskedValue(adjustedRaw, maskFormat, value);
     }
 
     if (parsedValue === '') {

--- a/packages/lib/src/VueDatePicker/components/DatePickerInput/useInput.ts
+++ b/packages/lib/src/VueDatePicker/components/DatePickerInput/useInput.ts
@@ -80,7 +80,7 @@ export const useInput = () => {
     return null;
   };
 
-  const createMaskedValue = (raw: string, maskFormat: string) => {
+  const createMaskedValue = (raw: string, maskFormat: string, sourceValue?: string) => {
     const tokenPattern = /(YYYY|MM|DD|hh|mm|ss)/g;
     const tokens: string[] = [...maskFormat.matchAll(tokenPattern)].map((m) => m[0]);
     const delimiters: string[] = maskFormat.replace(tokenPattern, '|').split('|').filter(Boolean);
@@ -93,7 +93,14 @@ export const useInput = () => {
       const part = raw.slice(index, index + len);
       if (!part) break;
       masked += part;
-      if (part.length === len && delimiters[i]) masked += delimiters[i];
+      if (part.length === len && delimiters[i]) {
+        const hasMoreRaw = raw.length > index + len;
+        const delimiterPosition = masked.length;
+        const hasDelimiterInSource = sourceValue?.charAt(delimiterPosition) === delimiters[i];
+        if (hasMoreRaw || hasDelimiterInSource) {
+          masked += delimiters[i];
+        }
+      }
       index += len;
     }
     return masked;


### PR DESCRIPTION


## Describe your changes
The root issue was in masked input reconstruction: delimiters were always re-appended when a token was complete, so after Backspace (01/01/ → 01/01) the / got injected back and felt “stuck”. I changed the mask builder to append a delimiter only when there are more raw digits to follow or that delimiter is still present in the user’s current input value.

Reproduced on master/v14

## Issue ticket number and link
Closes #1282

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test