### PR TITLE
Fix: Accessibility/keyboard-navigation regressions in the datepicker input and year-picker overlay.

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { addMonths, subMonths } from 'date-fns';
+import { mount, flushPromises } from '@vue/test-utils';
+import VueDatePickerRoot from '@/VueDatePickerRoot.vue';
 import {
   clearInput,
   closeMenu,
@@ -126,6 +128,157 @@ describe('Test Suite 1', () => {
 
       const dpClosedMenu = await closeMenu({});
       expect(dpClosedMenu.vm.dpWrapMenuRef()?.value).toBeNull();
+    });
+  });
+
+  describe('Keyboard navigation - Tab key', () => {
+    it('Should keep the menu open when Tab is pressed on an empty input and text input is disabled', async () => {
+      const dp = await openMenu({});
+      expect(dp.vm.dpWrapMenuRef()?.value).toBeTruthy();
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      await nextTick();
+
+      expect(dp.vm.dpWrapMenuRef()?.value).toBeTruthy();
+      expect(dp.emitted('cleared')).toBeUndefined();
+    });
+
+    it('Should keep the menu element rendered in the DOM after Tab on an empty input', async () => {
+      const dp = await openMenu({});
+      expect(dp.find('.dp--menu').exists()).toBe(true);
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      await nextTick();
+
+      expect(dp.find('.dp--menu').exists()).toBe(true);
+    });
+
+    it('Should still submit a valid typed date on Tab when text input is enabled', async () => {
+      const dp = await openMenu({ textInput: { format: 'MM/dd/yyyy' } });
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      await input.setValue('01/15/2026');
+      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      await nextTick();
+
+      expect(dp.emitted('text-submit')).toBeTruthy();
+    });
+
+    it('Should still clear parsed date and emit clear on Tab with empty input when text input is enabled', async () => {
+      const dp = await openMenu({ textInput: true, modelValue: new Date(2026, 2, 15) });
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      await input.setValue('');
+      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      await nextTick();
+
+      expect(dp.emitted('cleared')).toBeTruthy();
+    });
+  });
+
+  describe('Year picker', () => {
+    it('Should render the year overlay cell for start-date with a matching focus-value data attribute when model value is empty', async () => {
+      const startDate = new Date(2023, 0, 1);
+      const dp = await openMenu({ yearPicker: true, autoApply: true, modelValue: null, startDate });
+
+      const focusCell = dp.find('[data-dp-focus-value="2023"]');
+      expect(focusCell.exists()).toBe(true);
+    });
+
+    it('Should scroll the year overlay towards start-date year, not the first item in year-range, when model value is empty', async () => {
+      const originalDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetTop');
+      // jsdom always reports 0 for offsetTop, so every candidate cell would produce an identical
+      // scrollTop regardless of which one was picked. Faking a distinct offsetTop per cell (based
+      // on its focus-value data attribute) lets us prove the *correct* cell was the one used.
+      Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+        configurable: true,
+        get(this: HTMLElement) {
+          const focusValue = this.dataset?.dpFocusValue;
+          return focusValue ? Number(focusValue) * 10 : 0;
+        },
+      });
+
+      try {
+        const startDate = new Date(2023, 0, 1);
+        const dp = await openMenu({ yearPicker: true, autoApply: true, modelValue: null, startDate });
+
+        const container = dp.find('.dp--overlay-container').element as HTMLElement;
+        const firstYearInRange = 1900; // default yearRange start
+
+        expect(container.scrollTop).not.toBe(firstYearInRange * 10);
+        expect(container.scrollTop).toBe(2023 * 10 - 127.5);
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(HTMLElement.prototype, 'offsetTop', originalDescriptor);
+        }
+      }
+    });
+
+    it('Should focus the year cell matching start-date when the overlay opens', async () => {
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
+
+      try {
+        const startDate = new Date(2023, 0, 1);
+        const dp = await openMenu({ yearPicker: true, autoApply: true, modelValue: null, startDate });
+
+        const focusCell = dp.find('[data-dp-focus-value="2023"]').element as HTMLElement;
+        expect(focusSpy.mock.instances).toContain(focusCell);
+      } finally {
+        focusSpy.mockRestore();
+      }
+    });
+
+    it('Should not focus the year cell when no-overlay-focus is effectively enabled (text input mode)', async () => {
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
+
+      try {
+        const startDate = new Date(2023, 0, 1);
+        const dp = await openMenu({
+          yearPicker: true,
+          autoApply: true,
+          modelValue: null,
+          startDate,
+          textInput: true,
+        });
+
+        const focusCell = dp.find('[data-dp-focus-value="2023"]').element as HTMLElement;
+        expect(focusSpy.mock.instances).not.toContain(focusCell);
+      } finally {
+        focusSpy.mockRestore();
+      }
+    });
+
+    it('Should keep focus on the start-date year cell, not the first year in range, after the arrow-navigation focus watcher runs', async () => {
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
+      // useArrowNavigation.ts uses document.querySelector internally, which can only see elements
+      // that are actually attached to `document` - the shared `openMenu` helper mounts detached,
+      // so this test needs its own attachTo: document.body mount to exercise that code path.
+      const dp = mount(VueDatePickerRoot, {
+        props: { yearPicker: true, autoApply: true, modelValue: null, startDate: new Date(2023, 0, 1) },
+        attachTo: document.body,
+      });
+
+      try {
+        dp.vm.openMenu();
+        await flushPromises();
+        await dp.vm.$nextTick();
+
+        // useArrowNavigation's focus watcher runs on requestAnimationFrame (x2), scheduled after
+        // SelectionOverlay's own mount-time focus call. Flush both frames to let it settle.
+        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+        await nextTick();
+
+        const focusCell = dp.find('[data-dp-focus-value="2023"]').element as HTMLElement;
+        const firstCell = dp.find('[data-dp-focus-value="1900"]').element as HTMLElement;
+
+        expect(focusSpy.mock.instances).toContain(focusCell);
+        expect(focusSpy.mock.instances).not.toContain(firstCell);
+      } finally {
+        focusSpy.mockRestore();
+        dp.unmount();
+      }
     });
   });
 

--- a/packages/lib/src/VueDatePicker/components/Common/SelectionOverlay.vue
+++ b/packages/lib/src/VueDatePicker/components/Common/SelectionOverlay.vue
@@ -36,6 +36,8 @@
             :aria-disabled="col.disabled || undefined"
             :data-dp-action-element="level ?? 1"
             :data-dp-element-active="col.active ? (level ?? 1) : undefined"
+            :data-dp-focus-value="col.value"
+            :data-dp-focus-target="focusValue !== undefined && focusValue !== null && col.value === focusValue ? true : undefined"
             tabindex="0"
             :data-test-id="col.text"
             @click.prevent="onClick(col)"
@@ -92,6 +94,8 @@
     overlayLabel?: string;
     isLast: boolean;
     level?: 0 | 1 | 2;
+    focusValue?: number | null;
+    noOverlayFocus?: boolean;
   }>();
 
   const {
@@ -184,16 +188,24 @@
             config.value.modeHeight - toggleBtnHeight - (header?.getBoundingClientRect().height ?? 0);
         }
       }
-      const el = colRefs.value?.find((element) => {
+      const activeEl = colRefs.value?.find((element) => {
         const { dpElementActive } = element.dataset;
         return dpElementActive === `${props.level ?? 1}`;
       });
+      const focusEl =
+        props.focusValue !== undefined && props.focusValue !== null
+          ? colRefs.value?.find((element) => Number(element.dataset.dpFocusValue) === props.focusValue)
+          : undefined;
+      const el = activeEl ?? focusEl;
       if (el && container && setScroll) {
         container.scrollTop =
           el.offsetTop -
           container.offsetTop -
           (containerHeight.value / 2 - el.getBoundingClientRect().height) -
           toggleBtnHeight;
+      }
+      if (el && setScroll && !props.noOverlayFocus) {
+        el.focus({ preventScroll: true });
       }
     });
   };

--- a/packages/lib/src/VueDatePicker/components/DatePickerInput/DatepickerInput.vue
+++ b/packages/lib/src/VueDatePicker/components/DatePickerInput/DatepickerInput.vue
@@ -250,10 +250,15 @@
       parseInput((ev.target as HTMLInputElement).value);
     }
 
-    if (textInput.value.tabSubmit && isValidDate(parsedDate.value) && inputValue.value !== '') {
+    if (
+      textInput.value.enabled &&
+      textInput.value.tabSubmit &&
+      isValidDate(parsedDate.value) &&
+      inputValue.value !== ''
+    ) {
       emit('set-input-date', parsedDate.value, true, true);
       parsedDate.value = null;
-    } else if (textInput.value.tabSubmit && inputValue.value === '') {
+    } else if (textInput.value.enabled && textInput.value.tabSubmit && inputValue.value === '') {
       parsedDate.value = null;
       emit('clear');
     }

--- a/packages/lib/src/VueDatePicker/composables/useArrowNavigation.ts
+++ b/packages/lib/src/VueDatePicker/composables/useArrowNavigation.ts
@@ -164,7 +164,10 @@ export const useArrowNavigation = () => {
     if (active && !ignoreActive) {
       focusEl(active);
     } else {
-      const el = document.querySelector<HTMLElement>(`[data-dp-action-element="${level.value}"]`);
+      const el =
+        document.querySelector<HTMLElement>(
+          `[data-dp-focus-target="true"][data-dp-action-element="${level.value}"]`,
+        ) ?? document.querySelector<HTMLElement>(`[data-dp-action-element="${level.value}"]`);
       if (el) {
         focusEl(el);
       }


### PR DESCRIPTION
## Describe your changes
+ **Tab key closing the menu on empty input** — handleTab() in DatepickerInput.vue triggered its "submit"/"clear" branches even when free-text input mode was off, because textInput.tabSubmit defaults to true regardless. On an empty input, this fired emit('clear') → closeMenu() — closing the menu right as it received focus via Tab. Fixed by gating both branches on textInput.value.enabled, matching the guard already present on the parse branch.
+ **Year-picker overlay ignoring start-date and always scrolling to 1900** — YearPicker.vue passed focus-value to SelectionOverlay, but that component no longer declared the prop, so it was silently dropped and the overlay had nothing to scroll to when no year was selected. Fixed by restoring the focusValue prop and using it as a scroll-target fallback (after the "active/selected" cell) in SelectionOverlay.vue.
+ **Year/month overlays not auto-focusing on open (unlike time-picker)** — the noOverlayFocus prop was likewise passed by YearPicker.vue/MonthPicker.vue but never declared or implemented in SelectionOverlay.vue, so opening these overlays via keyboard never moved focus into the grid. Fixed by declaring the prop and focusing the active/target cell on mount (mirroring TimePicker.vue's existing pattern), unless noOverlayFocus is set.
+ **useArrowNavigation.ts silently overriding the above fix, refocusing year 1900** — a pre-existing, always-on focus watcher (independent of the arrow-navigation prop) fell back to document.querySelector('[data-dp-action-element="…"]') when nothing was selected, which just grabs the first cell in DOM order. This ran shortly after the new correct-cell focus and stole it back. Fixed by tagging the intended target cell with data-dp-focus-target and having this fallback prefer it before falling back to the first cell.

## Issue ticket number and link
Closes #1283
Closes #1291

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test