### PR TITLE
Fix: DataCloneError when selecting a date with a customPosition marker

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -8,7 +8,7 @@ import {
   openMenu,
   selectDate,
 } from '@/__tests__/tests-utils.ts';
-import { nextTick } from 'vue';
+import { nextTick, reactive } from 'vue';
 import { enGB } from 'date-fns/locale';
 import { WeekStart } from '@/constants';
 
@@ -126,6 +126,39 @@ describe('Test Suite 1', () => {
 
       const dpClosedMenu = await closeMenu({});
       expect(dpClosedMenu.vm.dpWrapMenuRef()?.value).toBeNull();
+    });
+  });
+
+  describe('Markers', () => {
+    it('Should not throw when clicking a date whose marker is defined via a reactive array (ref/reactive regression)', async () => {
+      const today = new Date();
+      // Mirrors a real-world consumer defining `const markers = ref([...])`: once Vue unwraps the
+      // ref, `.value` is a deeply reactive array, so building it with reactive() here reproduces
+      // that exact shape without needing a ref() unwrap step.
+      const reactiveMarkers = reactive([{ date: today, type: 'dot' as const }]);
+      const dp = await openMenu({ markers: reactiveMarkers, modelValue: null });
+
+      await expect(selectDate(dp, today)).resolves.not.toThrow();
+      expect(dp.emitted('date-click')).toBeTruthy();
+    });
+
+    it('Should still allow selecting a date whose marker is defined via a plain (non-reactive) array', async () => {
+      const today = new Date();
+      const dp = await openMenu({ markers: [{ date: today, type: 'dot' as const }], modelValue: null });
+
+      await expect(selectDate(dp, today)).resolves.not.toThrow();
+      expect(dp.emitted('date-click')).toBeTruthy();
+    });
+
+    it('Should still allow selecting a date whose marker uses a customPosition callback', async () => {
+      const today = new Date();
+      const dp = await openMenu({
+        markers: [{ date: today, type: 'dot' as const, customPosition: () => ({ top: '0px' }) }],
+        modelValue: null,
+      });
+
+      await expect(selectDate(dp, today)).resolves.not.toThrow();
+      expect(dp.emitted('date-click')).toBeTruthy();
     });
   });
 

--- a/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
+++ b/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
@@ -553,7 +553,13 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
   const selectDate = (day: CalendarDay, isNext = false): void => {
     if (isDisabled(day.value) || (!day.current && rootProps.hideOffsetDates))
       return rootEmit('invalid-date', day.value);
-    clickedDate.value = structuredClone(day);
+    // clickedDate is only ever read as a truthy/falsy flag (see shouldUpdateMonthView), so its
+    // `marker` never needs to be present on the clone. Excluding it here avoids structuredClone
+    // failing on data a marker may legitimately carry that can't be structurally cloned - a
+    // reactive Proxy (when markers are supplied via ref()/reactive()) or a customPosition
+    // callback function - while still snapshotting the rest of the day object defensively.
+    const { marker, ...clonableDay } = day;
+    clickedDate.value = { ...structuredClone(clonableDay), marker };
 
     if (!range.value.enabled) return handleSingleDateSelect(day);
 

--- a/packages/lib/src/VueDatePicker/composables/useDefaults.ts
+++ b/packages/lib/src/VueDatePicker/composables/useDefaults.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue';
+import { computed, toRaw } from 'vue';
 
 import { useHelperFns } from '@/composables';
 import {
@@ -213,7 +213,11 @@ export const useDefaults = (props: RootPropsWithDefaults) => {
         ? new Map(
             props.markers.map((marker) => {
               const date = getDate(marker.date);
-              return [getMapKey(date, MAP_KEY_FORMAT.DATE), marker];
+              // Unwrap potential Vue reactivity (e.g. when the consumer defines their markers
+              // array with ref()/reactive()) so downstream consumers - notably the
+              // structuredClone() call in useDatePicker's selectDate() - never receive a
+              // reactive Proxy, which structuredClone cannot clone (DataCloneError).
+              return [getMapKey(date, MAP_KEY_FORMAT.DATE), toRaw(marker)];
             }),
           )
         : null,


### PR DESCRIPTION
## Describe your changes
DataCloneError when selecting a date with a customPosition marker — selectDate() in useDatePicker.ts called structuredClone(day) on the full CalendarDay object to snapshot the clicked date. When a marker used a customPosition callback, this threw DataCloneError, since functions can't be structurally cloned. Fixed by excluding marker from the clone and reattaching it by reference, since clickedDate is only ever read as a truthy/falsy flag downstream and never needs marker present.

Related fix in useDefaults.ts — markers supplied via ref()/reactive() are also non-cloneable (reactive Proxies), which would have hit the same structuredClone failure. Fixed by unwrapping each marker with toRaw() when building the markers map in safeDates.

## Issue ticket number and link
Closes #1290

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test