### PR TITLE
fix: preserve locale in text-input formatting and react to locale prop changes

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@/__tests__/tests-utils.ts';
 import { nextTick } from 'vue';
 import { enGB } from 'date-fns/locale';
+import { de } from 'date-fns/locale';
 import { WeekStart } from '@/constants';
 
 describe('Test Suite 1', () => {
@@ -151,6 +152,39 @@ describe('Test Suite 1', () => {
 
         expect(headers[0].text()).toEqual('Mo');
       });
+    });
+  });
+
+  describe('Text input', () => {
+    it('Should keep the provided locale when formatting the text input on focus', async () => {
+      const dp = await openMenu({
+        modelValue: new Date(2026, 6, 15, 10, 30),
+        locale: de,
+        textInput: { format: 'dd LLLL yyyy HH:mm' },
+        formats: { input: 'dd LLLL yyyy HH:mm' },
+      });
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      await input.trigger('focus');
+      await nextTick();
+
+      expect((input.element as HTMLInputElement).value).toEqual('15 Juli 2026 10:30');
+    });
+
+    it('Should update the formatted text input immediately when locale changes, without requiring focus', async () => {
+      const dp = await openMenu({
+        modelValue: new Date(2026, 5, 21, 10, 30),
+        locale: enGB,
+        formats: { input: 'dd LLLL yyyy HH:mm' },
+      });
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      expect((input.element as HTMLInputElement).value).toEqual('21 June 2026 10:30');
+
+      await dp.setProps({ locale: de });
+      await nextTick();
+
+      expect((input.element as HTMLInputElement).value).toEqual('21 Juni 2026 10:30');
     });
   });
 });

--- a/packages/lib/src/VueDatePicker/composables/useExternalInternalMapper.ts
+++ b/packages/lib/src/VueDatePicker/composables/useExternalInternalMapper.ts
@@ -47,6 +47,14 @@ export const useExternalInternalMapper = () => {
     },
   );
 
+  // Re-format immediately whenever the locale changes so the input text stays in sync.
+  watch(
+    () => rootProps.locale,
+    () => {
+      formatInputValue();
+    },
+  );
+
   const getTimeVal = (date?: Date): TimeModel | ModelTypeConverted | null => {
     if (!date) return null;
     if (rootProps.modelType) return toModelType(date);

--- a/packages/lib/src/VueDatePicker/composables/useFormatter.ts
+++ b/packages/lib/src/VueDatePicker/composables/useFormatter.ts
@@ -51,7 +51,8 @@ export const useFormatter = () => {
   };
 
   const formatRangeTextInput = () => {
-    const formatter = (value: Date) => format(value, textInput.value.format as string);
+    const formatter = (value: Date) =>
+      format(value, textInput.value.format as string, { locale: rootProps.locale });
     if (Array.isArray(modelValue.value)) {
       return `${formatter(modelValue.value[0])}${textInput.value.rangeSeparator}${
         modelValue.value[1] ? formatter(modelValue.value[1]) : ''
@@ -65,7 +66,7 @@ export const useFormatter = () => {
     if (state.isInputFocused && modelValue.value) {
       if (Array.isArray(modelValue.value)) return formatRangeTextInput();
       if (typeof textInput.value.format === 'function') return textInput.value.format(modelValue.value as never);
-      return format(modelValue.value, textInput.value.format);
+      return format(modelValue.value, textInput.value.format, { locale: rootProps.locale });
     }
     return formatSelectedDate(modelValue.value);
   };


### PR DESCRIPTION
## Describe your changes
**Issue 1 — Text input ignores locale on focus**

Fixes: locale ignored when textInput.format is set and the input is focused

+ formatForTextInput() (in useFormatter.ts) now passes { locale: rootProps.locale } through to format() on both code paths — the single-date branch and the range branch (formatRangeTextInput()) — instead of only respecting the locale for the non-focused / non-textInput display path.
+ Root cause: when textInput.format was set and the input gained focus, the formatter fell through to date-fns's format() without an explicit locale option, so it silently used date-fns's default (en-US) instead of the locale passed via the locale prop. 
+ Added regression coverage:
	+ Single-date text input keeps the provided locale on focus (de locale, dd LLLL yyyy HH:mm format). 
	+ Verified the same fix also covers the range text-input formatting path (formatRangeTextInput).
	
**Issue 2 — Input text doesn't update when locale prop changes**

Fixes: locale prop changes not reflected until the input is focused

+ Added a watch(() => rootProps.locale, () => formatInputValue()) in useExternalInternalMapper.ts, mirroring the existing watcher on formats.value.input. 
+ Root cause: the formatted input text is only recomputed via formatInputValue(), which was previously only triggered by model-value changes, formats.input changes, or focus (handleInputFocus in VueDatePicker.vue). There was no watcher on rootProps.locale, so switching locales while the input wasn't focused left the displayed text stale until the next focus event. 
+ Added regression coverage:
	+ Mount with locale: enGB, assert formatted text, then setProps({ locale: de }) and assert the text updates immediately — with no focus trigger involved.

## Issue ticket number and link
Closes #1286
Closes #1284

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test