### PR TITLE
Fix: flow + auto-apply double-emitting update:model-value and menu getting stuck open on month reselect

### DIFF
--- a/packages/lib/src/VueDatePicker/VueDatePicker.vue
+++ b/packages/lib/src/VueDatePicker/VueDatePicker.vue
@@ -315,7 +315,7 @@
   const selectDate = (): void => {
     if (checkBeforeEmit() && validateBeforeEmit()) {
       emitModelValue();
-      closeMenu();
+      closeMenu(false, true);
     } else {
       rootEmit('invalid-select');
     }
@@ -325,7 +325,7 @@
     updateTextInputWithDateTimeValue();
     emitModelValue();
     if (config.value.closeOnAutoApply && !ignoreClose) {
-      closeMenu();
+      closeMenu(false, true);
     }
   };
 
@@ -357,7 +357,18 @@
     }
   };
 
-  const closeMenu = (fromClickAway = false): void => {
+  /**
+   * Close the menu.
+   *
+   * @param fromClickAway - whether the close was triggered by a click outside the picker.
+   * @param skipInputRevert - skip reverting `inputValue`/internal `modelValue` back to
+   * whatever the external `modelValue` prop currently holds. Pass `true` when the caller just
+   * committed a fresh value via `emitModelValue()` (e.g. auto-apply, explicit Select) - the
+   * revert exists to discard *uncommitted* state (like an in-progress text-input edit) when
+   * the menu closes without a selection, and must not run right after a real commit, since the
+   * external prop hasn't been updated by Vue yet at that point and would be stale.
+   */
+  const closeMenu = (fromClickAway = false, skipInputRevert = false): void => {
     watchRender.value = true;
     if (fromClickAway && modelValue.value && config.value.setDateOnMenuClose) {
       selectDate();
@@ -368,7 +379,7 @@
         setState('menuFocused', false);
         setState('shiftKeyInMenu', false);
         rootEmit('closed');
-        if (inputValue.value) {
+        if (!skipInputRevert && inputValue.value) {
           parseExternalModelValue(modelValueRef.value);
         }
       }

--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -9,6 +9,7 @@ import {
   selectDate,
 } from '@/__tests__/tests-utils.ts';
 import { nextTick } from 'vue';
+import { flushPromises } from '@vue/test-utils';
 import { enGB } from 'date-fns/locale';
 import { WeekStart } from '@/constants';
 
@@ -116,6 +117,78 @@ describe('Test Suite 1', () => {
       await nextTick();
 
       expect(dp.emitted('date-click')![0]![0]).toEqual(expectedModelDate);
+    });
+  });
+
+  describe('Flow with auto-apply', () => {
+    const frozenSystemDate = new Date(2026, 7, 21, 12, 30, 30);
+    beforeEach(() => {
+      vi.setSystemTime(frozenSystemDate);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('Should emit update:model-value exactly once when selecting a date with a single-step flow', async () => {
+      const dp = await openMenu({ autoApply: true, flow: { steps: ['calendar'] } });
+
+      const dateToSelect = new Date(2026, 7, 21);
+      await selectDate(dp, dateToSelect);
+      await flushPromises();
+      await nextTick();
+
+      const emitted = dp.emitted('update:model-value');
+      expect(emitted).toHaveLength(1);
+      expect(emitted![0][0]).not.toBeNull();
+    });
+
+    it('Should not clear the internal model value after selecting a date with a single-step flow', async () => {
+      const dp = await openMenu({ autoApply: true, flow: { steps: ['calendar'] } });
+
+      const dateToSelect = new Date(2026, 7, 21);
+      await selectDate(dp, dateToSelect);
+      await flushPromises();
+      await nextTick();
+
+      const input = dp.find('[data-test-id="dp-input"]');
+      expect((input.element as HTMLInputElement).value).not.toEqual('');
+    });
+
+    it('Should emit update:model-value exactly once when completing a range with a single-step flow', async () => {
+      const dp = await openMenu({
+        autoApply: true,
+        range: { partialRange: false },
+        flow: { steps: ['calendar'] },
+      });
+
+      const startDate = new Date(2026, 7, 21);
+      const endDate = new Date(2026, 7, 23);
+      await selectDate(dp, startDate);
+      await flushPromises();
+      await selectDate(dp, endDate);
+      await flushPromises();
+      await nextTick();
+
+      const emitted = dp.emitted('update:model-value');
+      expect(emitted).toHaveLength(1);
+      expect(emitted![0][0]).not.toBeNull();
+    });
+
+    it('Should close the menu after reselecting the currently displayed month at the month flow step, then picking a day', async () => {
+      const dp = await openMenu({ autoApply: true, flow: { steps: ['month', 'calendar'] } });
+      const activeMonthCell = dp.find('[data-dp-element-active="1"]');
+      expect(activeMonthCell.exists()).toBe(true);
+      await activeMonthCell.trigger('click');
+      await flushPromises();
+      await nextTick();
+
+      await selectDate(dp, frozenSystemDate);
+      await flushPromises();
+      await nextTick();
+
+      expect(dp.emitted('closed')).toBeTruthy();
+      expect(dp.emitted('update:model-value')).toBeTruthy();
     });
   });
 

--- a/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
+++ b/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
@@ -410,7 +410,7 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
     } else {
       modelValue.value = date;
     }
-    updateFlowStep('calendar');
+    updateFlowStep('calendar', true);
     nextTick().then(() => {
       autoApply();
     });
@@ -533,7 +533,7 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
       } else {
         assignTimeToRangeDate(0);
         assignTimeToRangeDate(1);
-        updateFlowStep('calendar');
+        updateFlowStep('calendar', true);
       }
       validateRangeAfterTimeSet();
       modelValue.value = tempRange.value.slice();
@@ -565,7 +565,6 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
 
   // Handles selection of month/year
   const updateMonthYear = (instance: number, val: { month: number; year: number; fromNav?: boolean }): void => {
-    const monthChanged = month.value(instance) !== val.month;
     setCalendarMonthYear(instance, val.month, val.year, false, true);
 
     if (multiCalendars.value.count && !multiCalendars.value.solo) {
@@ -573,8 +572,16 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
     }
     triggerCalendarTransition(multiCalendars.value.solo ? instance : undefined);
 
-    if (!val.fromNav) {
-      updateFlowStep(monthChanged ? 'month' : 'year');
+    // Advance whatever flow step is CURRENTLY active, rather than trying to infer which
+    // selector (month vs year) the user interacted with by comparing old/new values. That
+    // heuristic (`monthChanged`) breaks when the user reselects the value already displayed
+    // (e.g. taps the currently-shown month) - the value doesn't change, so it gets misread as
+    // a year selection, which doesn't match the current step name, and the flow silently gets
+    // stuck (menu never auto-applies/closes). This function is only ever invoked as a result
+    // of interacting with whichever overlay the active flow step corresponds to, so flowStep
+    // itself is the correct, reliable signal.
+    if (!val.fromNav && flowStep.value) {
+      updateFlowStep(flowStep.value);
     }
   };
 

--- a/packages/lib/src/VueDatePicker/components/MonthPicker/useMonthPicker.ts
+++ b/packages/lib/src/VueDatePicker/components/MonthPicker/useMonthPicker.ts
@@ -133,7 +133,7 @@ export const useMonthPicker = (emit: EmitFn<MonthPickerEmits>) => {
     const date = modelValue.value ? (modelValue.value as Date) : resetDate(getDate());
     modelValue.value = set(date, { month, year: year.value(instance) });
     emit('auto-apply');
-    updateFlowStep('month');
+    updateFlowStep('month', true);
   };
 
   const selectRangedMonth = (month: number, instance: number) => {

--- a/packages/lib/src/VueDatePicker/composables/useFlow.ts
+++ b/packages/lib/src/VueDatePicker/composables/useFlow.ts
@@ -6,7 +6,7 @@ import { useContext } from '@/composables/useContext.ts';
 import type { PickerSection } from '@/types';
 
 export const FlowKey = Symbol('FlowKey') as InjectionKey<{
-  updateFlowStep: (step: PickerSection) => void;
+  updateFlowStep: (step: PickerSection, skipAutoApplyEmit?: boolean) => void;
   childMount: (child?: CMP) => void;
   flowStep: Readonly<Ref<PickerSection | undefined>>;
 }>;
@@ -40,7 +40,21 @@ export const useFlow = (dynCmpRef: Ref, emit: EmitFn<{ 'auto-apply': [ignoreClos
     }
   };
 
-  const updateFlowStep = (step: PickerSection): void => {
+  /**
+   * Advance the flow to the next configured step.
+   *
+   * When there is no next step (the current step is the last one in the flow),
+   * this schedules its own `auto-apply` emission on `nextTick` - this is required for
+   * steps whose callers (e.g. time steps in `useTimePickerUtils`) don't emit `auto-apply`
+   * themselves.
+   *
+   * Some callers (e.g. calendar day selection, range selection, month selection) already
+   * schedule their own `auto-apply` emission independently of the flow. For those, pass
+   * `skipAutoApplyEmit = true` to avoid a duplicate `auto-apply` emission - which, on the
+   * last flow step, would fire once with the selected value and then a second time with a
+   * stale/cleared value after the menu has already closed.
+   */
+  const updateFlowStep = (step: PickerSection, skipAutoApplyEmit = false): void => {
     if (flow.value?.steps?.length) {
       if (flowStep.value === step) {
         const nextStep = flow.value.steps.at(flow.value.steps.indexOf(flowStep.value) + 1);
@@ -48,7 +62,7 @@ export const useFlow = (dynCmpRef: Ref, emit: EmitFn<{ 'auto-apply': [ignoreClos
           flowStep.value = nextStep;
           rootEmit('flow-step', flowStep.value);
           executeFlow();
-        } else if (rootProps.autoApply) {
+        } else if (rootProps.autoApply && !skipAutoApplyEmit) {
           nextTick().then(() => emit('auto-apply'));
         }
       }


### PR DESCRIPTION
## Describe your changes
+ **Selecting a date on the flow's last step with auto-apply enabled emitted update:model-value twice (the selected date, then null)** — useFlow.ts's updateFlowStep() always scheduled its own auto-apply emission when there was no next step, but callers like handleSingleDateSelect/range selection/month selection (useDatePicker.ts, useMonthPicker.ts) already scheduled their own auto-apply independently. Both firing meant the second call ran after the menu (and internal model) had already been reset by the first, emitting a stale null right after the real value. Fixed by adding a skipAutoApplyEmit flag to updateFlowStep(), passed as true by every caller that already handles its own auto-apply emission, so the flow's own last-step emission is skipped in those cases.
+ **That same double-commit path also let closeMenu() wipe out the just-selected value** — closeMenu()'s revert-to-external-prop logic (meant to discard an uncommitted, in-progress edit when the menu closes without a selection) ran immediately after emitModelValue() had already committed the new value, but read rootProps.modelValue, which Vue hasn't propagated from the parent's v-model yet at that point in the call stack — so it reverted to a stale value instead. Fixed by adding a skipInputRevert flag to closeMenu(), passed as true from selectDate() and emitOnAutoApply() (VueDatePicker.vue) right after they commit a value, so the revert only runs for genuine close-without-selection cases.
+ **With flow: ['month', 'calendar'], reselecting the month that's already displayed left the menu stuck open** — updateMonthYear() in useDatePicker.ts decided which flow step to advance by comparing the old and new month values (monthChanged). Reselecting the currently-shown month means the value doesn't change, so this heuristic misread it as a year selection, which didn't match the active step name, and the flow silently got stuck instead of advancing to calendar. Fixed by advancing whatever flow step is currently active (flowStep.value) directly instead of re-deriving it from a value comparison, since updateMonthYear is only ever invoked as a result of interacting with the overlay the active step already corresponds to.

## Issue ticket number and link
Closes #1295
Closes #1296

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test