### PR TITLE
feature: add `requireEndTime` config to show end-time input on single-day selection with `model-auto`

### DIFF
--- a/packages/docs/docs/props/modes-configuration/index.md
+++ b/packages/docs/docs/props/modes-configuration/index.md
@@ -25,6 +25,7 @@ interface RangeConfig {
     minRange?: string | number;
     autoRange?: string | number;
     autoSwitchStartEnd?: boolean;
+    requireEndTime?: boolean;
 }
 ```
 
@@ -297,6 +298,35 @@ some custom validation logic
 ```vue
 <template>
   <VueDatePicker v-model="date" :range="{ autoSwitchStartEnd: false }"  />
+</template>
+
+<script setup>
+  import { VueDatePicker } from "@vuepic/vue-datepicker";
+  import { ref } from 'vue';
+
+  const date = ref();
+</script>
+```
+:::
+
+### `requireEndTime`
+
+Used together with [`model-auto`](/props/modes/#model-auto). By default, the end-time input in the time picker only appears once a full 2-day range has been selected (either by clicking two different days, or by double-clicking the same day) - a single click only shows the start time.
+
+Enabling this option shows the end-time input immediately after a single click, seeding the end date to the same day as the start, so a 1-day event can be given its own start and end time without the double-click workaround.
+
+::: warning
+Only has an effect when `model-auto` is also enabled. When combined with `auto-apply`, a single click will immediately produce a complete `[start, end]` pair and close the menu - you may want to leave `auto-apply` off so the user can adjust the end time before confirming.
+:::
+
+- Default: `false`
+
+<GlobalDemo :range="{ requireEndTime: true }" :modelAuto="true" placeholder="Select single date or range"></GlobalDemo>
+
+::: details Code Example
+```vue
+<template>
+  <VueDatePicker v-model="date" model-auto :range="{ requireEndTime: true }" />
 </template>
 
 <script setup>

--- a/packages/docs/docs/props/modes/index.md
+++ b/packages/docs/docs/props/modes/index.md
@@ -386,6 +386,10 @@ Since this prop uses [`range.partialRange`](/props/modes-configuration/#partialr
 This is only compatible with date pickers; specific modes are not supported
 :::
 
+:::tip
+Want to require both a start and end time, even when the user only clicks a single day (e.g. building a 1-day event with its own start and end time)? See [`range.requireEndTime`](/props/modes-configuration/#requireendtime).
+:::
+
 <GlobalDemo :modelAuto="true" :range="true" placeholder="Select single date or range"></GlobalDemo>
 
 ::: details Code Example

--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { addMonths, subMonths } from 'date-fns';
+import { addDays, addMonths, format, subMonths } from 'date-fns';
 import {
   clearInput,
   closeMenu,
@@ -11,6 +11,7 @@ import {
 import { nextTick } from 'vue';
 import { enGB } from 'date-fns/locale';
 import { WeekStart } from '@/constants';
+import type { MonthModel } from '@/types';
 
 describe('Test Suite 1', () => {
   describe('multi-calendars', () => {
@@ -151,6 +152,461 @@ describe('Test Suite 1', () => {
 
         expect(headers[0].text()).toEqual('Mo');
       });
+    });
+  });
+
+  describe('Multi-select month & year pickers', () => {
+    const frozenSystemDate = new Date(2026, 0, 15, 12, 0, 0);
+
+    beforeEach(() => {
+      vi.setSystemTime(frozenSystemDate);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    describe('Month picker', () => {
+      it('Should select multiple months when auto-apply is enabled', async () => {
+        const dp = await openMenu({ monthPicker: true, multiDates: true, autoApply: true });
+
+        await dp.find('[data-test-id="Jan"]').trigger('click');
+        await dp.find('[data-test-id="Mar"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as MonthModel[];
+
+        expect(lastValue).toHaveLength(2);
+        expect(lastValue[0]).toEqual({ month: 0, year: 2026 });
+        expect(lastValue[1]).toEqual({ month: 2, year: 2026 });
+      });
+
+      it('Should deselect a month when it is clicked again', async () => {
+        const dp = await openMenu({ monthPicker: true, multiDates: true, autoApply: true });
+
+        await dp.find('[data-test-id="Jan"]').trigger('click');
+        await dp.find('[data-test-id="Mar"]').trigger('click');
+        await dp.find('[data-test-id="Jan"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as MonthModel[];
+
+        expect(lastValue).toHaveLength(1);
+        expect(lastValue[0]).toEqual({ month: 2, year: 2026 });
+      });
+
+      it('Should respect the multi-dates limit', async () => {
+        const dp = await openMenu({ monthPicker: true, multiDates: { limit: 2 }, autoApply: true });
+
+        await dp.find('[data-test-id="Jan"]').trigger('click');
+        await dp.find('[data-test-id="Feb"]').trigger('click');
+        await dp.find('[data-test-id="Mar"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as MonthModel[];
+
+        expect(lastValue).toHaveLength(2);
+        expect(lastValue.map((v) => v.month)).toEqual([0, 1]);
+      });
+
+      it('Should mark previously selected months as active', async () => {
+        const dp = await openMenu({
+          monthPicker: true,
+          multiDates: true,
+          modelValue: [
+            { month: 0, year: 2026 },
+            { month: 2, year: 2026 },
+          ],
+        });
+
+        expect(dp.find('[data-test-id="Jan"]').attributes('aria-selected')).toBe('true');
+        expect(dp.find('[data-test-id="Mar"]').attributes('aria-selected')).toBe('true');
+        expect(dp.find('[data-test-id="Feb"]').attributes('aria-selected')).toBeUndefined();
+      });
+
+      it('Should not emit a value until the selection is confirmed (default autoApply)', async () => {
+        const dp = await openMenu({ monthPicker: true, multiDates: true });
+
+        await dp.find('[data-test-id="Jan"]').trigger('click');
+        await dp.find('[data-test-id="Mar"]').trigger('click');
+
+        expect(dp.emitted('update:model-value')).toBeUndefined();
+
+        await dp.find('[data-test-id="select-button"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as MonthModel[];
+        expect(lastValue).toHaveLength(2);
+        expect(lastValue.map((v) => v.month)).toEqual([0, 2]);
+      });
+    });
+
+    describe('Year picker', () => {
+      it('Should select multiple years when auto-apply is enabled', async () => {
+        const dp = await openMenu({ yearPicker: true, multiDates: true, autoApply: true });
+
+        await dp.find('[data-test-id="2025"]').trigger('click');
+        await dp.find('[data-test-id="2026"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as number[];
+
+        expect(lastValue).toEqual([2025, 2026]);
+      });
+
+      it('Should deselect a year when it is clicked again', async () => {
+        const dp = await openMenu({ yearPicker: true, multiDates: true, autoApply: true });
+
+        await dp.find('[data-test-id="2025"]').trigger('click');
+        await dp.find('[data-test-id="2026"]').trigger('click');
+        await dp.find('[data-test-id="2025"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as number[];
+
+        expect(lastValue).toEqual([2026]);
+      });
+
+      it('Should mark previously selected years as active', async () => {
+        const dp = await openMenu({
+          yearPicker: true,
+          multiDates: true,
+          modelValue: [2025, 2026],
+        });
+
+        expect(dp.find('[data-test-id="2025"]').attributes('aria-selected')).toBe('true');
+        expect(dp.find('[data-test-id="2026"]').attributes('aria-selected')).toBe('true');
+        expect(dp.find('[data-test-id="2027"]').attributes('aria-selected')).toBeUndefined();
+      });
+
+      it('Should not emit a value until the selection is confirmed (default autoApply)', async () => {
+        const dp = await openMenu({ yearPicker: true, multiDates: true });
+
+        await dp.find('[data-test-id="2025"]').trigger('click');
+        await dp.find('[data-test-id="2026"]').trigger('click');
+
+        expect(dp.emitted('update:model-value')).toBeUndefined();
+
+        await dp.find('[data-test-id="select-button"]').trigger('click');
+
+        const emitted = dp.emitted('update:model-value')!;
+        const lastValue = emitted[emitted.length - 1]![0] as number[];
+        expect(lastValue).toEqual([2025, 2026]);
+      });
+    });
+  });
+
+  describe('range picker - requireEndTime', () => {
+    it('Should hide the end-time input for a single-day modelAuto selection by default', async () => {
+      const dp = await openMenu({
+        range: true,
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date());
+
+      const timeInputs = dp.findAll('.dp--time-input');
+      expect(timeInputs).toHaveLength(2);
+      expect(timeInputs[0]!.isVisible()).toBe(true);
+      expect(timeInputs[1]!.isVisible()).toBe(false);
+    });
+
+    it('Should show the end-time input for a single-day modelAuto selection when requireEndTime is true', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date());
+
+      const timeInputs = dp.findAll('.dp--time-input');
+      expect(timeInputs).toHaveLength(2);
+      expect(timeInputs[0]!.isVisible()).toBe(true);
+      expect(timeInputs[1]!.isVisible()).toBe(true);
+    });
+
+    it('Should keep showing both time inputs once a full range is selected, regardless of requireEndTime', async () => {
+      const dp = await openMenu({
+        range: true,
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      await selectDate(dp, today);
+      await selectDate(dp, today);
+
+      const timeInputs = dp.findAll('.dp--time-input');
+      expect(timeInputs).toHaveLength(2);
+      expect(timeInputs[0]!.isVisible()).toBe(true);
+      expect(timeInputs[1]!.isVisible()).toBe(true);
+    });
+
+    it('Should default requireEndTime to false when range is passed as a plain boolean', async () => {
+      const dp = await openMenu({
+        range: true,
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date());
+
+      expect(dp.findAll('.dp--time-input')[1]!.isVisible()).toBe(false);
+    });
+
+    it('Should seed a real, independent end date on a single-day click so the end-time input persists its own value', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      await selectDate(dp, today);
+      await dp.find('[data-test-id="minutes-time-inc-btn-1"]').trigger('click');
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(lastValue[0]).toBeInstanceOf(Date);
+      expect(lastValue[1]).toBeInstanceOf(Date);
+
+      // Single-day event: same calendar day for start and end.
+      expect(lastValue[1].getDate()).toBe(lastValue[0].getDate());
+      expect(lastValue[1].getMonth()).toBe(lastValue[0].getMonth());
+      expect(lastValue[1].getFullYear()).toBe(lastValue[0].getFullYear());
+      expect(lastValue[1].getMinutes()).not.toBe(lastValue[0].getMinutes());
+    });
+
+    it('Should keep the start and end times independent after closing and reopening the menu', async () => {
+      const today = new Date();
+      const startDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0);
+      const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 45, 0);
+
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+        modelValue: [startDate, endDate],
+      });
+
+      const timeInputs = dp.findAll('.dp--time-input');
+      expect(timeInputs).toHaveLength(2);
+      expect(timeInputs[0]!.isVisible()).toBe(true);
+      expect(timeInputs[1]!.isVisible()).toBe(true);
+
+      const startMinutesText = dp.find('[data-test-id="minutes-toggle-overlay-btn-0"]').text();
+      const endMinutesText = dp.find('[data-test-id="minutes-toggle-overlay-btn-1"]').text();
+
+      expect(startMinutesText).not.toBe(endMinutesText);
+      expect(endMinutesText).toContain('45');
+    });
+
+    it('Should let a second click on a different day extend an auto-seeded single-day range, not restart it', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      const tomorrow = addDays(today, 1);
+
+      await selectDate(dp, today);
+      await selectDate(dp, tomorrow);
+
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(tomorrow, 'yyyy-MM-dd'));
+    });
+
+    it('Should let a second click on an EARLIER day extend an auto-seeded single-day range correctly', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      const threeDaysAgo = addDays(today, -3);
+
+      await selectDate(dp, today);
+      await selectDate(dp, threeDaysAgo);
+
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(threeDaysAgo, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
+    });
+
+    it('Should start a fresh auto-seeded range after a genuine 2-day range was already completed', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      const tomorrow = addDays(today, 1);
+      const inThreeDays = addDays(today, 3);
+
+      await selectDate(dp, today);
+      await selectDate(dp, tomorrow);
+      await selectDate(dp, inThreeDays);
+
+      const timeInputs = dp.findAll('.dp--time-input');
+      expect(timeInputs[0]!.isVisible()).toBe(true);
+      expect(timeInputs[1]!.isVisible()).toBe(true);
+
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(inThreeDays, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(inThreeDays, 'yyyy-MM-dd'));
+    });
+  });
+
+  describe('range picker - multi-day selection', () => {
+    it('Should select a plain multi-day range from two distinct clicks', async () => {
+      const dp = await openMenu({ range: true });
+
+      const today = new Date();
+      const inFiveDays = addDays(today, 5);
+
+      await selectDate(dp, today);
+      await selectDate(dp, inFiveDays);
+
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(inFiveDays, 'yyyy-MM-dd'));
+    });
+
+    it('Should let both start and end times be edited independently on a real multi-day requireEndTime range', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      const inTwoDays = addDays(today, 2);
+
+      await selectDate(dp, today);
+      await selectDate(dp, inTwoDays);
+
+      // Bump start hours and end minutes independently.
+      await dp.find('[data-test-id="hours-time-inc-btn-0"]').trigger('click');
+      await dp.find('[data-test-id="minutes-time-inc-btn-1"]').trigger('click');
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(inTwoDays, 'yyyy-MM-dd'));
+      expect(lastValue[1]!.getMinutes()).not.toBe(lastValue[0]!.getMinutes());
+    });
+  });
+
+  describe('range picker - requireEndTime side-effect safety', () => {
+    it('Should NOT auto-seed an end date when requireEndTime is set but modelAuto is off', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      await selectDate(dp, today);
+
+      const timeInputs = dp.findAll('.dp--time-input');
+      expect(timeInputs).toHaveLength(2);
+
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0];
+      expect(Array.isArray(lastValue) ? lastValue.filter(Boolean).length : 0).toBeLessThan(2);
+    });
+
+    it('Should leave plain range selection (no requireEndTime, no modelAuto) completely unaffected', async () => {
+      const dp = await openMenu({ range: true, timeConfig: { timePickerInline: true } });
+
+      const today = new Date();
+      const inFiveDays = addDays(today, 5);
+
+      await selectDate(dp, today);
+      await selectDate(dp, inFiveDays);
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(inFiveDays, 'yyyy-MM-dd'));
+    });
+
+    it('Should leave fixedStart range selection unaffected even when requireEndTime is also set', async () => {
+      const today = new Date();
+      const fixedStart = today;
+
+      const dp = await openMenu({
+        range: { fixedStart: true, requireEndTime: true },
+        modelAuto: true,
+        modelValue: [fixedStart, null],
+        timeConfig: { timePickerInline: true },
+      });
+
+      const inFiveDays = addDays(today, 5);
+      await selectDate(dp, inFiveDays);
+      await dp.find('[data-test-id="select-button"]').trigger('click');
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(fixedStart, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(inFiveDays, 'yyyy-MM-dd'));
+    });
+
+    it('Should immediately auto-apply and close on a single click when requireEndTime is combined with autoApply', async () => {
+      const dp = await openMenu({
+        range: { requireEndTime: true },
+        modelAuto: true,
+        autoApply: true,
+        timeConfig: { timePickerInline: true },
+      });
+
+      const today = new Date();
+      await selectDate(dp, today);
+
+      const emitted = dp.emitted('update:model-value')!;
+      const lastValue = emitted[emitted.length - 1]![0] as Date[];
+
+      expect(lastValue).toHaveLength(2);
+      expect(format(lastValue[0]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
+      expect(format(lastValue[1]!, 'yyyy-MM-dd')).toBe(format(today, 'yyyy-MM-dd'));
     });
   });
 });

--- a/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
+++ b/packages/lib/src/VueDatePicker/components/DatePicker/useDatePicker.ts
@@ -33,7 +33,7 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
   const tempRange = ref<Date[]>([]);
   const lastScrollTime = ref(new Date());
   const clickedDate = ref<CalendarDay | undefined>();
-
+  const autoSeededSingleDayRange = ref(false);
   const {
     getDate,
     getDateFromParts,
@@ -425,7 +425,11 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
   // Before range selecting, ensure that modelValue is properly set
   const presetTempRange = () => {
     tempRange.value = modelValue.value ? (modelValue.value as Date[]).slice().filter((val) => !!val) : [];
-    if (tempRange.value.length === 2 && !(range.value.fixedStart || range.value.fixedEnd)) {
+    if (
+      tempRange.value.length === 2 &&
+      !(range.value.fixedStart || range.value.fixedEnd) &&
+      !autoSeededSingleDayRange.value
+    ) {
       tempRange.value = [];
     }
   };
@@ -474,7 +478,12 @@ export const useDatePicker = (emit: EmitFn<DatePickerEmits>, triggerCalendarTran
     if (!tempRange.value[0]) {
       tempRange.value[0] = getDate(day.value);
       rootEmit('range-start', tempRange.value[0]);
+      if (range.value.requireEndTime && rootProps.modelAuto) {
+        tempRange.value[1] = getDate(day.value);
+        autoSeededSingleDayRange.value = true;
+      }
     } else if (checkMinMaxRange(getDate(day.value), modelValue.value) && !includesDisabled(day.value)) {
+      autoSeededSingleDayRange.value = false;
       if (isDateBefore(getDate(day.value), getDate(tempRange.value[0]))) {
         if (range.value.autoSwitchStartEnd) {
           tempRange.value.unshift(getDate(day.value));

--- a/packages/lib/src/VueDatePicker/components/TimePicker/TimePicker.vue
+++ b/packages/lib/src/VueDatePicker/components/TimePicker/TimePicker.vue
@@ -158,7 +158,9 @@
   });
 
   const shouldShowRangedInput = computed(() => {
-    if (range.value.enabled && rootProps.modelAuto) return isModelAuto(modelValue.value);
+    if (range.value.enabled && rootProps.modelAuto && !range.value.requireEndTime) {
+      return isModelAuto(modelValue.value);
+    }
     return true;
   });
 

--- a/packages/lib/src/VueDatePicker/constants/defaults.ts
+++ b/packages/lib/src/VueDatePicker/constants/defaults.ts
@@ -12,6 +12,7 @@ export const defaultRangeOptions = {
   fixedStart: false,
   fixedEnd: false,
   autoSwitchStartEnd: true,
+  requireEndTime: false,
 };
 
 export const defaultConfig = {

--- a/packages/lib/src/VueDatePicker/types/configs.ts
+++ b/packages/lib/src/VueDatePicker/types/configs.ts
@@ -140,6 +140,7 @@ export interface RangeConfig {
   maxRange?: string | number;
   minRange?: string | number;
   autoRange?: string | number;
+  requireEndTime?: boolean;
   autoSwitchStartEnd: boolean;
 }
 


### PR DESCRIPTION
## Describe your changes

Adds a new `range.requireEndTime` config option. When used together with `model-auto`, it forces the end-time input to always be shown and editable — even after only a single day has been clicked — instead of only appearing once a genuine 2-day range exists.

## Problem

With `model-auto` + `range` + time enabled, the end-time input only appears once `modelValue` contains both a start and end date. For a single click (a 1-day event), only the start-time input showed. The only existing workaround was double-clicking the same day to force both start and end to the same date — not discoverable, and not something you can prompt the user to do.

## Solution

- Added `requireEndTime?: boolean` to `RangeConfig` (default `false`, opt-in, fully backwards compatible).
- `TimePicker.vue`'s `shouldShowRangedInput` now always shows the end-time input when `range.requireEndTime` is set, instead of gating on `isModelAuto(modelValue)`.
- `useDatePicker.ts`'s `handleRangeDatesSelect` now auto-seeds the end date to the same day as the start on a single click, when `model-auto` + `range.requireEndTime` are both enabled. This reproduces the same end-state as the old double-click workaround, automatically, on the first click.
- Added an `autoSeededSingleDayRange` flag so a second click correctly *extends* the auto-seeded single-day range (to an earlier or later day) instead of being treated as a fresh, unrelated selection. `presetTempRange` was updated to respect this flag so it doesn't wipe out the auto-seeded range before the extending click is processed.
- Only takes effect when `model-auto` is also enabled; has no effect on plain `range` mode, `fixedStart`/`fixedEnd`, or non-`model-auto` usage.

<img width="399" height="478" alt="image" src="https://github.com/user-attachments/assets/204eab4f-397f-45f1-8801-d112eb963fb0" />

```
<script>
const demo9Range = ref<Date[] | null>(null);
</script>
<VueDatePicker
        v-model="demo9Range"
        model-auto
        :range="{ requireEndTime: true }"
        :locale="en"
        :formats="{ month: 'LLLL', input: formatDemo9Input }"
        :action-row="{ showCancel: false, selectBtnLabel: 'Confirm' }"
        :time-config="{ timePickerInline: true }"
        :floating="alwaysOpenBelow"
        class="lv-demo"
      />
```


## Issue ticket number and link
Closes #1265

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test