### PR TITLE
fix: disable out-of-range hours/minutes when minDate/maxDate include a time component

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -153,4 +153,68 @@ describe('Test Suite 1', () => {
       });
     });
   });
+
+  describe('minDate/maxDate with a time component', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date(2026, 1, 5, 9, 0));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('Should disable hours before minDate on the minDate day itself', async () => {
+      const dp = await openMenu({
+        minDate: new Date(2026, 1, 10, 11, 0),
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date(2026, 1, 10));
+      await dp.find('[data-test-id="hours-toggle-overlay-btn-0"]').trigger('click');
+
+      expect(dp.find('[data-test-id="10"]').attributes('aria-disabled')).toEqual('true');
+      expect(dp.find('[data-test-id="11"]').attributes('aria-disabled')).toBeUndefined();
+    });
+
+    it('Should not disable any hours on a day after minDate', async () => {
+      const dp = await openMenu({
+        minDate: new Date(2026, 1, 10, 11, 0),
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date(2026, 1, 11));
+      await dp.find('[data-test-id="hours-toggle-overlay-btn-0"]').trigger('click');
+
+      expect(dp.find('[data-test-id="10"]').attributes('aria-disabled')).toBeUndefined();
+      expect(dp.find('[data-test-id="11"]').attributes('aria-disabled')).toBeUndefined();
+    });
+
+    it('Should disable minutes before minDate on the boundary hour', async () => {
+      const dp = await openMenu({
+        minDate: new Date(2026, 1, 10, 11, 30),
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date(2026, 1, 10));
+      await dp.find('[data-test-id="hours-toggle-overlay-btn-0"]').trigger('click');
+      await dp.find('[data-test-id="11"]').trigger('click');
+      await dp.find('[data-test-id="minutes-toggle-overlay-btn-0"]').trigger('click');
+
+      expect(dp.find('[data-test-id="15"]').attributes('aria-disabled')).toEqual('true');
+      expect(dp.find('[data-test-id="35"]').attributes('aria-disabled')).toBeUndefined();
+    });
+
+    it('Should disable hours after maxDate on the maxDate day itself', async () => {
+      const dp = await openMenu({
+        maxDate: new Date(2026, 1, 10, 11, 0),
+        timeConfig: { timePickerInline: true },
+      });
+
+      await selectDate(dp, new Date(2026, 1, 10));
+      await dp.find('[data-test-id="hours-toggle-overlay-btn-0"]').trigger('click');
+
+      expect(dp.find('[data-test-id="12"]').attributes('aria-disabled')).toEqual('true');
+      expect(dp.find('[data-test-id="11"]').attributes('aria-disabled')).toBeUndefined();
+    });
+  });
 });

--- a/packages/lib/src/VueDatePicker/components/TimePicker/useTimePickerUtils.ts
+++ b/packages/lib/src/VueDatePicker/components/TimePicker/useTimePickerUtils.ts
@@ -1,5 +1,5 @@
 import { computed, nextTick } from 'vue';
-import { isAfter, isBefore, setMilliseconds, setSeconds } from 'date-fns';
+import { getHours, getMinutes, getSeconds, isAfter, isBefore, isSameDay, setMilliseconds, setSeconds } from 'date-fns';
 
 import { useContext, useDateUtils } from '@/composables';
 
@@ -12,7 +12,7 @@ export const useTimePickerUtils = () => {
     modelValue,
     time,
     rootProps,
-    defaults: { range, timeConfig },
+    defaults: { range, timeConfig, safeDates },
   } = useContext();
   const { updateFlowStep } = useFlowContext();
 
@@ -160,19 +160,64 @@ export const useTimePickerUtils = () => {
   };
 
   const disabledTimesConfig = computed(() => (ind: number, hoursVal?: number) => {
+    const minMaxDisabled = getMinMaxDisabledTimes(ind, hoursVal);
+
     if (Array.isArray(rootProps.disabledTimes)) {
       const { disabledArr, hours } = getDisabledTimesData(ind, hoursVal);
 
       const timeFound = disabledArr.filter((time) => +time.hours === hours);
       if (timeFound[0]?.minutes === '*') return { hours: [hours], minutes: undefined, seconds: undefined };
       return {
-        hours: [],
-        minutes: timeFound?.map((t) => +t.minutes) ?? [],
-        seconds: timeFound?.map((t) => (t.seconds ? +t.seconds : undefined)) ?? [],
+        hours: minMaxDisabled.hours,
+        minutes: [...(timeFound?.map((t) => +t.minutes) ?? []), ...minMaxDisabled.minutes],
+        seconds: [...(timeFound?.map((t) => (t.seconds ? +t.seconds : undefined)) ?? []), ...minMaxDisabled.seconds],
       };
     }
-    return { hours: [], minutes: [], seconds: [] };
+    return minMaxDisabled;
   });
+
+  /**
+   * Disables hour/minute/second overlay options that fall outside `minDate`/`maxDate`
+   * when either carries a time component and the day currently being edited is the boundary day itself
+   */
+  const getMinMaxDisabledTimes = (ind: number, hoursVal?: number) => {
+    const disabled = { hours: [] as number[], minutes: [] as number[], seconds: [] as number[] };
+
+    const baseDate = (range.value.enabled ? (modelValue.value as Date[])?.[ind] : (modelValue.value as Date)) ?? null;
+    if (!baseDate) return disabled;
+
+    const { hours: selectedHour } = getDisabledTimesData(ind, hoursVal);
+
+    if (safeDates.value.minDate && isSameDay(baseDate, safeDates.value.minDate)) {
+      const minHour = getHours(safeDates.value.minDate);
+      const minMinute = getMinutes(safeDates.value.minDate);
+      const minSecond = getSeconds(safeDates.value.minDate);
+
+      for (let h = 0; h < minHour; h += 1) disabled.hours.push(h);
+      if (selectedHour === minHour) {
+        for (let m = 0; m < minMinute; m += 1) disabled.minutes.push(m);
+        if (timeConfig.value.enableSeconds) {
+          for (let s = 0; s < minSecond; s += 1) disabled.seconds.push(s);
+        }
+      }
+    }
+
+    if (safeDates.value.maxDate && isSameDay(baseDate, safeDates.value.maxDate)) {
+      const maxHour = getHours(safeDates.value.maxDate);
+      const maxMinute = getMinutes(safeDates.value.maxDate);
+      const maxSecond = getSeconds(safeDates.value.maxDate);
+
+      for (let h = maxHour + 1; h < 24; h += 1) disabled.hours.push(h);
+      if (selectedHour === maxHour) {
+        for (let m = maxMinute + 1; m < 60; m += 1) disabled.minutes.push(m);
+        if (timeConfig.value.enableSeconds) {
+          for (let s = maxSecond + 1; s < 60; s += 1) disabled.seconds.push(s);
+        }
+      }
+    }
+
+    return disabled;
+  };
 
   return {
     assignTime,


### PR DESCRIPTION
## Describe your changes
- `useTimePickerUtils.ts` now also pulls in `safeDates` (the already-parsed `minDate`/`maxDate` used by the confirm-time validator, for consistency).
- Added `getMinMaxDisabledTimes(ind, hoursVal)`, which - only when the day currently being edited is the boundary day itself (`isSameDay` against `minDate`/`maxDate`) - disables:
  - hours before `minDate`'s hour / after `maxDate`'s hour
  - minutes before/after the boundary minute, once the boundary hour is selected
- Merged into the existing `disabledTimesConfig` computed via union, so it layers on top of the `disabledTimes` array/function feature rather than replacing it.
- On any day other than the boundary day, no extra restriction is applied - the calendar's day-level disabling already covers that case.

<img width="344" height="294" alt="image" src="https://github.com/user-attachments/assets/12322977-6177-41ea-80a1-562b4aa645cd" />


## Issue ticket number and link
Closes #1252

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test