### PR TITLE
fix: Manual date input

### DIFF
--- a/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/TestSuite_1.spec.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { addMonths, subMonths } from 'date-fns';
+import { enUS } from 'date-fns/locale';
 import {
   clearInput,
   closeMenu,
   getMonthToggleBtn,
   getMonthToggleText,
   openMenu,
+  openMenuWithFocusedInput,
   selectDate,
 } from '@/__tests__/tests-utils.ts';
 import { nextTick } from 'vue';
@@ -151,6 +153,62 @@ describe('Test Suite 1', () => {
 
         expect(headers[0].text()).toEqual('Mo');
       });
+    });
+  });
+
+  describe('Arrow navigation', () => {
+    it('Should keep focus on the text input when the menu opens while typing', async () => {
+      const dp = await openMenuWithFocusedInput({ textInput: true, arrowNavigation: true });
+      const input = dp.find('[data-test-id="dp-input"]');
+
+      expect(document.activeElement).toBe(input.element);
+
+      dp.unmount();
+    });
+  });
+
+  describe('Text input format (AM/PM)', () => {
+    const props = {
+      locale: enUS,
+      timeConfig: { enableTimePicker: true, is24: false },
+      textInput: { format: 'MM/dd/yyyy hh:mm aa' },
+    };
+
+    const typeAndSubmit = async (dp: Awaited<ReturnType<typeof openMenu>>, value: string) => {
+      const input = dp.find<HTMLInputElement>('[data-test-id="dp-input"]');
+      await input.setValue(value);
+      await input.trigger('keydown', { key: 'Enter' });
+      const emitted = dp.emitted('update:model-value');
+      return emitted?.[emitted.length - 1]?.[0] as Date | undefined;
+    };
+
+    it('[control] Should parse a plain 24h date+time with no AM/PM token', async () => {
+      const dp = await openMenu({ textInput: { format: 'MM/dd/yyyy HH:mm' } });
+      const value = await typeAndSubmit(dp, '07/01/2026 14:00');
+
+      expect(value?.getHours()).toBe(14);
+    });
+
+    it('Should parse a PM time as 24h hours (12:00 PM -> 12)', async () => {
+      const dp = await openMenu(props);
+      const value = await typeAndSubmit(dp, '07/01/2026 12:00 PM');
+
+      expect(value?.getHours()).toBe(12);
+    });
+
+    it('Should parse a 12 AM time as midnight (12:00 AM -> 0)', async () => {
+      const dp = await openMenu(props);
+      const value = await typeAndSubmit(dp, '07/01/2026 12:00 AM');
+
+      expect(value?.getHours()).toBe(0);
+    });
+
+    it('Should parse an afternoon PM time correctly (01:30 PM -> 13)', async () => {
+      const dp = await openMenu(props);
+      const value = await typeAndSubmit(dp, '07/01/2026 01:30 PM');
+
+      expect(value?.getHours()).toBe(13);
+      expect(value?.getMinutes()).toBe(30);
     });
   });
 });

--- a/packages/lib/src/VueDatePicker/__tests__/tests-utils.ts
+++ b/packages/lib/src/VueDatePicker/__tests__/tests-utils.ts
@@ -40,3 +40,17 @@ export const getMonthToggleText = (date: Date) => {
 export const clearInput = (dp: DPInstance) => {
   return dp.find(`[data-test-id="clear-input-value-btn"]`).trigger('click');
 };
+
+// Attaches the component to `document.body` and focuses the text input before opening menu,
+// so `document.activeElement` behaves like in a real browser
+export const openMenuWithFocusedInput = async (props: Partial<RootProps>): Promise<DPInstance> => {
+  const dp = mount(VueDatePickerRoot, { props, attachTo: document.body });
+
+  dp.find<HTMLInputElement>('[data-test-id="dp-input"]').element.focus();
+
+  dp.vm.openMenu();
+  await flushPromises();
+
+  await dp.vm.$nextTick();
+  return dp;
+};

--- a/packages/lib/src/VueDatePicker/composables/useArrowNavigation.ts
+++ b/packages/lib/src/VueDatePicker/composables/useArrowNavigation.ts
@@ -63,15 +63,15 @@ export const useArrowNavigation = () => {
     if (![EventKey.arrowUp, EventKey.arrowDown, EventKey.arrowLeft, EventKey.arrowRight].includes(ev.key as never)) {
       return;
     }
-    buildMatrix();
-
-    ev.preventDefault();
 
     const currentElement = document.activeElement as HTMLElement;
 
     if (!currentElement?.hasAttribute('data-dp-action-element')) {
       return;
     }
+
+    buildMatrix();
+    ev.preventDefault();
 
     let currentRowIndex = -1;
     let currentColIndex = -1;
@@ -171,9 +171,14 @@ export const useArrowNavigation = () => {
     }
   };
 
+  const isTypingInTextInput = () =>
+    textInput.value.enabled && document.activeElement?.getAttribute('data-test-id') === 'dp-input';
+
   onMounted(() => {
     if (rootProps.arrowNavigation) {
-      focusInitial(false);
+      if (!isTypingInTextInput()) {
+        focusInitial(false);
+      }
       document.addEventListener('keydown', handleKeyDown);
     }
   });


### PR DESCRIPTION
## Describe your changes
+ Skip the auto-focus-into-grid on mount when the currently focused element is the text input (detected via its data-test-id="dp-input" attribute) — focus now stays put so typing can continue.
+ Reordered handleKeyDown to check data-dp-action-element first and only call preventDefault/navigate when focus is genuinely on a grid cell. Arrow keys now behave natively while typing, and still drive grid navigation once focus is actually in the calendar.

## Issue ticket number and link
Closes #1301
Closes #1234

## Checklist before requesting a review
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/Vuepic/vue-datepicker/blob/main/CONTRIBUTING.md) guidlines
- [x] I have performed a self-review of my code
- [x] I have ensured that unit tests pass without errors
- [x] I have ensured that `pnpm --filter @vuepic/vue-datepicker build` passes without errors
- [x] If it is a new feature, I have added a new unit test