### PR TITLE
Upgrade `@floating-ui/vue` to 2.x

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@date-fns/tz": "^1.5.0",
-    "@floating-ui/vue": "^1.1.11",
+    "@floating-ui/vue": "^2.0.1",
     "@vueuse/core": "^14.3.0",
     "date-fns": "^4.4.0"
   },


### PR DESCRIPTION
Upgrade `@floating-ui/vue` to 2.x, this removes the dependency on the soon-to-be deprecated package [vue-demi](https://github.com/vueuse/vue-demi).
The dependency on `vue-demi` has issues with Vue >=3.3.0.

https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fvue%402.0.0

---

I am currently running this datepicker in production without problems using this config:
```json
"overrides": {
    "@vuepic/vue-datepicker": {
        "@floating-ui/vue": "2.0.1"
    }
}
```